### PR TITLE
Remove manual Version/Last Updated metadata from dt-app-notebooks

### DIFF
--- a/skills/dt-app-notebooks/SKILL.md
+++ b/skills/dt-app-notebooks/SKILL.md
@@ -177,8 +177,3 @@ This skill uses **progressive disclosure** - load only what you need:
 
 - **dt-dql-essentials** - DQL query syntax, functions, and optimization
 - **dt-app-dashboards** - Dashboard creation for operational monitoring (vs notebooks for investigation)
-
----
-
-**Version**: 2.0.0  
-**Last Updated**: 2026-02-06


### PR DESCRIPTION
## Summary

- Removes the manual `**Version**: 2.0.0` and `**Last Updated**: 2026-02-06` lines from the bottom of `dt-app-notebooks/SKILL.md`
- Git commit history already tracks version and date information reliably
- Manual metadata like this tends to go stale; no other skill uses this pattern