### PR TITLE
feat: add CI validation and test suite

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/workflows/**"
       - "skills/**"
       - "plugins/**"
       - ".claude-plugin/**"

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,44 @@
+name: Validate skills
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "skills/**"
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "tests/**"
+      - "scripts/**"
+      - "AGENTS.md"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "llms.txt"
+  pull_request:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "plugins/**"
+      - ".claude-plugin/**"
+      - "tests/**"
+      - "scripts/**"
+      - "AGENTS.md"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "llms.txt"
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run tests
+        run: ./tests/run-all.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+*.pyc
+__pycache__/
+.venv/
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Run all tests and report pass/fail summary.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TESTS=(
+  test-skill-quality.sh
+  test-structure.sh
+)
+
+pass=0
+fail=0
+failures=()
+
+for test in "${TESTS[@]}"; do
+  echo ""
+  echo "━━━ Running $test ━━━"
+  if bash "$SCRIPT_DIR/$test"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    failures+=("$test")
+  fi
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: $pass passed, $fail failed (out of ${#TESTS[@]})"
+if [[ $fail -gt 0 ]]; then
+  echo "Failed tests:"
+  for f in "${failures[@]}"; do
+    echo "  ✗ $f"
+  done
+  exit 1
+fi
+echo "All tests passed."

--- a/tests/test-skill-quality.sh
+++ b/tests/test-skill-quality.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Test: Validate SKILL.md quality across all skills.
+#
+# Checks:
+#   1. Every SKILL.md has required frontmatter fields: name, description, license
+#   2. Skill name matches parent directory name
+#   3. Skill name is valid kebab-case, max 64 chars
+#   4. Description is ≤250 chars (Claude Code truncation threshold)
+#   5. Description is ≤1024 chars (Agent Skills spec hard limit)
+#   6. No trailing whitespace in frontmatter fields
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "=== test-skill-quality.sh ==="
+
+python3 -c "
+import re, sys, pathlib
+
+root = pathlib.Path('$ROOT_DIR')
+skills_dir = root / 'skills'
+errors = []
+warnings = []
+
+def parse_frontmatter(text):
+    m = re.search(r'^---\s*\n(.*?)\n---\s*', text, re.DOTALL)
+    if not m:
+        return {}
+    data = {}
+    for line in m.group(1).splitlines():
+        if ':' not in line or line.strip().startswith('#'):
+            continue
+        key, value = line.split(':', 1)
+        data[key.strip()] = value.strip()
+    return data
+
+for skill_dir in sorted(skills_dir.iterdir()):
+    if not skill_dir.is_dir() or not skill_dir.name.startswith('dt-'):
+        continue
+    skill_md = skill_dir / 'SKILL.md'
+    if not skill_md.exists():
+        errors.append(f'{skill_dir.name}: missing SKILL.md')
+        continue
+
+    text = skill_md.read_text(encoding='utf-8')
+    fm = parse_frontmatter(text)
+    name = skill_dir.name
+
+    # 1. Required fields
+    for field in ('name', 'description', 'license'):
+        if field not in fm or not fm[field]:
+            errors.append(f'{name}: missing required frontmatter field \"{field}\"')
+
+    if 'name' not in fm:
+        continue
+
+    fm_name = fm['name']
+    fm_desc = fm.get('description', '')
+
+    # 2. Name matches directory
+    if fm_name != name:
+        errors.append(f'{name}: frontmatter name \"{fm_name}\" does not match directory name')
+
+    # 3. Name format: kebab-case, max 64 chars
+    if not re.match(r'^[a-z0-9][a-z0-9-]*$', fm_name):
+        errors.append(f'{name}: name \"{fm_name}\" is not valid kebab-case')
+    if len(fm_name) > 64:
+        errors.append(f'{name}: name exceeds 64 chars ({len(fm_name)})')
+
+    # 4. Description ≤250 chars (Claude Code truncation warning)
+    if len(fm_desc) > 250:
+        warnings.append(f'{name}: description is {len(fm_desc)} chars, exceeds 250 (Claude Code truncates in plugin listing)')
+
+    # 5. Description ≤1024 chars (Agent Skills spec hard limit)
+    if len(fm_desc) > 1024:
+        errors.append(f'{name}: description is {len(fm_desc)} chars, exceeds Agent Skills spec limit of 1024')
+
+    # 6. Trailing whitespace in frontmatter
+    m = re.search(r'^---\s*\n(.*?)\n---\s*', text, re.DOTALL)
+    if m:
+        for i, line in enumerate(m.group(1).splitlines(), 1):
+            if line != line.rstrip():
+                warnings.append(f'{name}: trailing whitespace in frontmatter line {i}')
+
+if warnings:
+    for w in warnings:
+        print(f'WARNING: {w}')
+
+if errors:
+    for e in errors:
+        print(f'FAIL: {e}', file=sys.stderr)
+    sys.exit(1)
+
+print('  All skill quality checks passed')
+"
+
+echo "PASS: test-skill-quality.sh"

--- a/tests/test-structure.sh
+++ b/tests/test-structure.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 # Test: Validate structural consistency between skills/, plugin symlinks, and marketplace.json.
 #
 # Checks:
-#   1. Every skill dir has SKILL.md with valid frontmatter
+#   1. Every skill dir has SKILL.md
 #   2. Every skill in skills/ has a corresponding symlink in plugins/dynatrace/skills/
 #   3. marketplace.json is valid and references the dynatrace plugin
 #   4. marketplace.json source uses ./ prefix
@@ -35,7 +35,7 @@ plugin_skills_dir = root / 'plugins' / 'dynatrace' / 'skills'
 if plugin_skills_dir.exists():
     linked_skills = set()
     for entry in sorted(plugin_skills_dir.iterdir()):
-        if entry.is_symlink() or entry.is_dir():
+        if entry.name.startswith('dt-') and entry.is_symlink():
             linked_skills.add(entry.name)
 
     missing = sorted(disk_skills - linked_skills)
@@ -63,12 +63,11 @@ if not mp_path.exists():
 else:
     mp = json.loads(mp_path.read_text())
     plugins = mp.get('plugins', [])
-    if len(plugins) != 1:
-        errors.append(f'Expected 1 plugin in marketplace.json, found {len(plugins)}')
-    elif plugins[0].get('name') != 'dynatrace':
-        errors.append(f'Plugin name is \"{plugins[0].get(\"name\")}\" not \"dynatrace\"')
-    elif not plugins[0].get('source', '').startswith('./'):
-        errors.append(f'Plugin source should start with ./ but is: {plugins[0].get(\"source\")}')
+    dynatrace_plugin = next((plugin for plugin in plugins if plugin.get('name') == 'dynatrace'), None)
+    if dynatrace_plugin is None:
+        errors.append('marketplace.json does not reference the \"dynatrace\" plugin')
+    elif not dynatrace_plugin.get('source', '').startswith('./'):
+        errors.append(f'Plugin source should start with ./ but is: {dynatrace_plugin.get(\"source\")}')
 
 if errors:
     for e in errors:

--- a/tests/test-structure.sh
+++ b/tests/test-structure.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Test: Validate structural consistency between skills/, plugin symlinks, and marketplace.json.
+#
+# Checks:
+#   1. Every skill dir has SKILL.md with valid frontmatter
+#   2. Every skill in skills/ has a corresponding symlink in plugins/dynatrace/skills/
+#   3. marketplace.json is valid and references the dynatrace plugin
+#   4. marketplace.json source uses ./ prefix
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "=== test-structure.sh ==="
+
+python3 -c "
+import json, sys, os, re, pathlib
+
+root = pathlib.Path('$ROOT_DIR')
+errors = []
+
+# --- Discover skills on disk ---
+skills_dir = root / 'skills'
+disk_skills = set()
+for d in sorted(skills_dir.iterdir()):
+    if d.is_dir() and d.name.startswith('dt-'):
+        skill_md = d / 'SKILL.md'
+        if skill_md.exists():
+            disk_skills.add(d.name)
+        else:
+            errors.append(f'Skill dir {d.name}/ has no SKILL.md')
+
+# --- Check plugin skill symlinks ---
+plugin_skills_dir = root / 'plugins' / 'dynatrace' / 'skills'
+if plugin_skills_dir.exists():
+    linked_skills = set()
+    for entry in sorted(plugin_skills_dir.iterdir()):
+        if entry.is_symlink() or entry.is_dir():
+            linked_skills.add(entry.name)
+
+    missing = sorted(disk_skills - linked_skills)
+    extra = sorted(linked_skills - disk_skills)
+    if missing:
+        errors.append(f'Plugin missing skill symlinks: {missing}')
+    if extra:
+        errors.append(f'Plugin has symlinks to non-existent skills: {extra}')
+else:
+    errors.append('Missing plugins/dynatrace/skills/ directory')
+
+# --- Check plugin.json ---
+plugin_json_path = root / 'plugins' / 'dynatrace' / '.claude-plugin' / 'plugin.json'
+if not plugin_json_path.exists():
+    errors.append('Missing plugins/dynatrace/.claude-plugin/plugin.json')
+else:
+    pj = json.loads(plugin_json_path.read_text())
+    if pj.get('name') != 'dynatrace':
+        errors.append(f'plugin.json name is \"{pj.get(\"name\")}\" not \"dynatrace\"')
+
+# --- Check marketplace.json ---
+mp_path = root / '.claude-plugin' / 'marketplace.json'
+if not mp_path.exists():
+    errors.append('Missing .claude-plugin/marketplace.json')
+else:
+    mp = json.loads(mp_path.read_text())
+    plugins = mp.get('plugins', [])
+    if len(plugins) != 1:
+        errors.append(f'Expected 1 plugin in marketplace.json, found {len(plugins)}')
+    elif plugins[0].get('name') != 'dynatrace':
+        errors.append(f'Plugin name is \"{plugins[0].get(\"name\")}\" not \"dynatrace\"')
+    elif not plugins[0].get('source', '').startswith('./'):
+        errors.append(f'Plugin source should start with ./ but is: {plugins[0].get(\"source\")}')
+
+if errors:
+    for e in errors:
+        print(f'FAIL: {e}', file=sys.stderr)
+    sys.exit(1)
+
+print(f'  {len(disk_skills)} skills on disk, all linked in plugin')
+print('  marketplace.json valid')
+"
+
+echo "PASS: test-structure.sh"


### PR DESCRIPTION
## What

Adds automated validation for skill quality and structural consistency.

### Changes

- **GitHub Actions workflow** (`.github/workflows/validate-skills.yml`): runs tests on push/PR to main
- **Test suite** (`tests/`):
  - `test-skill-quality.sh` — validates SKILL.md frontmatter (name, description, license), naming conventions, description length
  - `test-structure.sh` — ensures every skill in `skills/` has a matching symlink in `plugins/dynatrace/skills/`, validates marketplace.json
  - `run-all.sh` — test runner with pass/fail summary
- **`.gitignore`** — standard patterns (.DS_Store, .venv, IDE files)

### Why

Catches structural drift and skill quality issues automatically — especially useful when skills are synced from the internal knowledge base.

### Test results

All tests pass against current main:

```
PASS: test-skill-quality.sh (2 warnings for >250 char descriptions, not blocking)
PASS: test-structure.sh (12 skills on disk, all linked)
```
