### PR TITLE
docs: list Azure, GCP, predictive analytics skills; fix prompt links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ The **[Dynatrace MCP server](https://docs.dynatrace.com/docs/shortlink/dynatrace
 | [dt-obs-hosts](skills/dt-obs-hosts/SKILL.md) | Host and process metrics: CPU, memory, disk, network, and containers. |
 | [dt-obs-kubernetes](skills/dt-obs-kubernetes/SKILL.md) | Kubernetes clusters, pods, nodes, workloads, labels, and resource relationships. |
 | [dt-obs-aws](skills/dt-obs-aws/SKILL.md) | AWS resources: EC2, RDS, Lambda, ECS/EKS, VPC, load balancers, and cost optimization. |
+| [dt-obs-azure](skills/dt-obs-azure/SKILL.md) | Azure resources: VMs, VMSS, SQL Database, Storage, AKS, App Service, Functions, VNet, Event Hubs, Container Apps, and Key Vault. |
+| [dt-obs-gcp](skills/dt-obs-gcp/SKILL.md) | GCP resources: Compute Engine, GKE, Cloud Run, Pub/Sub, VPC, DNS, IAM, and Secret Manager. |
 | [dt-obs-logs](skills/dt-obs-logs/SKILL.md) | Log queries, filtering, pattern analysis, and log correlation. |
 | [dt-obs-problems](skills/dt-obs-problems/SKILL.md) | Problem entities, root cause analysis, impact assessment, and problem correlation. |
+| [dt-obs-predictive-analytics](skills/dt-obs-predictive-analytics/SKILL.md) | Time series forecasting, capacity saturation planning, and trend/anomaly detection across hosts, services, and infrastructure. |
 ### Platform
 
 | Skill | Description |
@@ -90,12 +93,12 @@ Each prompt references the relevant skills above — load those skills first for
 
 | Prompt | Description |
 |--------|-------------|
-| [daily-standup](prompts/daily-standup.prompt.md) | Generate a daily standup report for one or more services. |
-| [health-check](prompts/health-check.prompt.md) | Check the health of a service in production. |
-| [incident-response](prompts/incident-response.prompt.md) | Respond to an active production incident with triage, root cause, and a shareable report. |
-| [investigate-error](prompts/investigate-error.prompt.md) | Investigate recent errors using Davis Problems as the entry point (problems → logs → traces). |
-| [performance-regression](prompts/performance-regression.prompt.md) | Analyze whether a recent deployment caused a performance regression. |
-| [troubleshoot-problem](prompts/troubleshoot-problem.prompt.md) | Troubleshoot an existing Dynatrace problem with structured log and trace investigation. |
+| [dt-daily-standup](prompts/dt-daily-standup.prompt.md) | Generate a daily standup report for one or more services. |
+| [dt-health-check](prompts/dt-health-check.prompt.md) | Check the health of a service in production. |
+| [dt-incident-response](prompts/dt-incident-response.prompt.md) | Respond to an active production incident with triage, root cause, and a shareable report. |
+| [dt-investigate-error](prompts/dt-investigate-error.prompt.md) | Investigate recent errors using Davis Problems as the entry point (problems → logs → traces). |
+| [dt-performance-regression](prompts/dt-performance-regression.prompt.md) | Analyze whether a recent deployment caused a performance regression. |
+| [dt-troubleshoot-problem](prompts/dt-troubleshoot-problem.prompt.md) | Troubleshoot an existing Dynatrace problem with structured log and trace investigation. |
 
 ## How Skills Work
 

--- a/llms.txt
+++ b/llms.txt
@@ -44,8 +44,11 @@ Observability:
 - dt-obs-hosts: Host/process CPU, memory, disk, network, containers.
 - dt-obs-kubernetes: K8s clusters, pods, nodes, workloads, labels.
 - dt-obs-aws: AWS EC2, RDS, Lambda, ECS/EKS, VPC, cost optimization.
+- dt-obs-azure: Azure VMs, VMSS, SQL Database, Storage, AKS, App Service, Functions, VNet, Event Hubs, Container Apps, Key Vault.
+- dt-obs-gcp: GCP Compute Engine, GKE, Cloud Run, Pub/Sub, VPC, DNS, IAM, Secret Manager.
 - dt-obs-logs: Log queries, filtering, pattern analysis, correlation.
 - dt-obs-problems: Problem entities, root cause, impact assessment.
+- dt-obs-predictive-analytics: Time series forecasting, capacity saturation, trend and anomaly detection.
 Dynatrace Apps:
 - dt-app-dashboards: Dashboard JSON, tiles, layouts, DQL queries, variables.
 - dt-app-notebooks: Notebook JSON, sections, analytics workflows.
@@ -58,12 +61,12 @@ Migration:
 Reusable task templates for common Dynatrace workflows. Paste directly into chat,
 or copy into .github/prompts/ for VS Code/Copilot slash command support.
 
-- daily-standup: Generate a daily standup report for one or more services.
-- health-check: Check the health of a service in production.
-- incident-response: Active incident triage — Davis Problems, root cause, user impact, shareable report.
-- investigate-error: Investigate errors via Davis Problems as entry point (problems → logs → traces).
-- performance-regression: Analyze whether a recent deployment caused a performance regression.
-- troubleshoot-problem: Structured problem investigation with log scoping, error classification, and trace analysis.
+- dt-daily-standup: Generate a daily standup report for one or more services.
+- dt-health-check: Check the health of a service in production.
+- dt-incident-response: Active incident triage — Davis Problems, root cause, user impact, shareable report.
+- dt-investigate-error: Investigate errors via Davis Problems as entry point (problems → logs → traces).
+- dt-performance-regression: Analyze whether a recent deployment caused a performance regression.
+- dt-troubleshoot-problem: Structured problem investigation with log scoping, error classification, and trace analysis.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- **Add three skills missing from the docs.** `dt-obs-azure`, `dt-obs-gcp`, and `dt-obs-predictive-analytics` ship in `skills/` and are registered in the dynatrace plugin, but were not listed in the README's Observability table or in `llms.txt`. Added them now.
- **Fix broken prompt links.** All six prompt links in README.md and llms.txt pointed at filenames without the `dt-` prefix (e.g. `prompts/daily-standup.prompt.md`), but the actual files ship as `prompts/dt-daily-standup.prompt.md`. Updated all links and identifiers to match.

## Verification

`./tests/run-all.sh` passes.