### PR TITLE
docs: clarify that skill content is read-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,30 @@
 # Contributing
 
-## How Skills Are Maintained
+## Skill Content Is Read-Only
 
-Skills in this repository are developed, tested, and verified internally at
-Dynatrace before being published here. Skill content under `skills/` is
-overwritten on each publish cycle — do not edit those files directly.
+Skill content under `skills/` is **maintained internally at Dynatrace** and
+published to this repository periodically. Every publish cycle overwrites the
+`skills/` directory entirely, so **pull requests that modify files under
+`skills/` will not be accepted** — the changes would be lost on the next
+publish.
+
+If you want to suggest improvements to a skill, please **open an issue**
+instead. The Dynatrace team will pick it up and apply the change at the source.
+
+## What You Can Contribute
+
+The following files live exclusively in this repository and welcome PRs:
+
+- `README.md`, `CONTRIBUTING.md`, `llms.txt`
+- `prompts/**` — reusable prompt templates
+- `plugins/**` — plugin manifests and agent configurations
+- `tests/**` — CI test scripts
+- `.github/**` — GitHub Actions workflows
 
 ## Reporting Issues
 
-To report issues or suggest improvements to skill content, please open a
-GitHub issue in this repository.
+To report bugs, suggest new skills, or request improvements to existing skill
+content, please [open a GitHub issue](../../issues/new).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Install all skills without penalty. Agents only load what they need.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+Skill content (`skills/`) is maintained internally at Dynatrace and published here periodically. **PRs that modify skill files will not be accepted** — please [open an issue](../../issues/new) instead to suggest changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on what can be contributed directly.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrote CONTRIBUTING.md to explicitly state that `skills/` is read-only and PRs modifying skill files will not be accepted
- Added a "What You Can Contribute" section listing files that do accept PRs
- Updated README.md Contributing section with the same guidance inline