### PR TITLE
AppEngine Skill 

### DIFF
--- a/prompts/dt-app-appengine.prompt.md
+++ b/prompts/dt-app-appengine.prompt.md
@@ -1,0 +1,158 @@
+# Prompt — Create a Dynatrace AppEngine Application
+
+Use this as the **first paste into Claude (Sonnet → Opus if needed)** when starting a new customer app from this template. Fill in every `«bracketed»` field. Delete sections you genuinely don't need rather than leaving them empty — empty fields generate generic output.
+
+Paired workflow: `designing_dynatrace_apps_with_claude.md` (9-step process). This prompt covers Steps 1–3 in one shot. Steps 4–9 happen in follow-up turns.
+
+---
+
+## Paste this into Claude
+
+```
+You are helping me design a Dynatrace AppEngine application for a real customer.
+I am a Dynatrace Solutions Engineer. The output will be shown to the customer and
+deployed to their tenant, so it must be customer-quality — not a throwaway.
+
+────────────────────────────────────────────────────────────────────────────
+CONTEXT
+────────────────────────────────────────────────────────────────────────────
+Customer:           «customer name, e.g. Cardinal Health»
+Tenant URL:         «https://«tenantid».apps.dynatrace.com»
+Industry / domain:  «e.g. healthcare distribution, airline ops, financial services»
+Primary users:      «role + seniority, e.g. SRE leads, TechOps managing director»
+Decision they make: «the specific decision the app should improve»
+Current workaround: «what they do today — spreadsheets, classic dashboards, paging RCA»
+Pain / why now:     «what makes the current state unacceptable»
+
+────────────────────────────────────────────────────────────────────────────
+PROBLEM STATEMENT (one sentence)
+────────────────────────────────────────────────────────────────────────────
+«One sentence. Lead with the user's problem, not the app you think you want.»
+
+Example pattern:
+"«User role» cannot see «critical signal» before «bad outcome», so they react
+instead of getting ahead."
+
+────────────────────────────────────────────────────────────────────────────
+SCOPE
+────────────────────────────────────────────────────────────────────────────
+Tabs / views:          «list 2–5; one sentence each on purpose»
+Data sources in scope: «e.g. dt.davis.problems, spans, logs, host metrics, K8s events»
+Data sources OUT of scope: «be explicit — saves correction cycles»
+Drill-down behavior:   «which tile opens which app/intent»
+Refresh cadence:       «live / 1 min / 5 min / on-demand»
+Global filters:        «tier, environment, application tag, time range, etc.»
+
+────────────────────────────────────────────────────────────────────────────
+VISUAL DIRECTION
+────────────────────────────────────────────────────────────────────────────
+Theme:        «dark / light / both — prefer dark for ops»
+Density:      «sparse hero-style / dense analyst-style»
+Inspiration:  «name 1–2 real products or screenshots if you can paste them»
+Brand colors (Dynatrace primary palette — use these, do not invent):
+  Blues:    #1C5BE5  #4635D6  #1497FF  #54C8E9
+  Purples:  #B23BE4  #6C3AD6  #6F2EA8
+  Greens:   #BDDF28  #73BE28
+  Pink:     #E436FF
+Tone:        «product-grade React UI, not Strato-default wireframe»
+
+────────────────────────────────────────────────────────────────────────────
+OUT OF SCOPE FOR THIS PASS
+────────────────────────────────────────────────────────────────────────────
+«Anything you do NOT want Claude to design yet — auth flows, admin pages,
+exotic visualizations, mobile responsiveness, etc.»
+
+────────────────────────────────────────────────────────────────────────────
+WHAT I WANT FROM YOU, IN THIS ORDER
+────────────────────────────────────────────────────────────────────────────
+1. **Pressure-test the idea first.** Give me:
+   - the strongest version of this app,
+   - the weakest assumption I am making,
+   - the one thing that, if I get it wrong, makes this useless to the user.
+   Do not move on until I respond.
+
+2. **Once I approve the direction, produce an HTML artifact mockup** with:
+   - realistic placeholder data (numbers, app names, host counts that make sense
+     for «customer industry»),
+   - the brand palette applied,
+   - information hierarchy that matches the user's decision flow
+     (what they need first must be biggest and topmost),
+   - density tuned per the Visual Direction above.
+
+3. **After the mockup renders, wait for my feedback** before iterating.
+   Do not auto-refine — I want to review the structure first.
+
+4. **When I say "wire to real data,"** use the Dynatrace MCP connected to
+   «tenant URL» to query the tenant. For each tile:
+   - write the DQL,
+   - execute it,
+   - update the mockup with real returned values,
+   - show both the DQL and the values in chat,
+   - STOP if any query returns nothing or obviously wrong data — do not
+     invent placeholder values.
+
+5. **When I say "generate the spec,"** produce a complete implementation-ready
+   design specification for Claude Code covering:
+   - AppEngine structure, permissions, intents
+   - routing and reusable React components
+   - global filters and their DQL impact
+   - DQL per tile with real field names (not pseudocode)
+   - drill-down behavior and AppEngine intent contracts
+   - phased build plan with acceptance criteria
+   - known limitations and future work
+   Target length: 800–1500 lines of markdown.
+
+────────────────────────────────────────────────────────────────────────────
+GUARDRAILS
+────────────────────────────────────────────────────────────────────────────
+- Never invent DQL field names. If you are not sure a field exists, say so and
+  propose `describe` queries to confirm.
+- Never fabricate Dynatrace product features that do not exist.
+- Prefer Smartscape (`smartscapeNodes`) over classic `dt.entity.*` entity queries.
+- For multi-aggregation `summarize`, wrap in curly braces.
+- Do not put inline math inside `makeTimeseries` aggregation parameters —
+  compute raw, then convert with `fieldsAdd`.
+- Tenant URL must use `.apps.dynatrace.com`, not `.live.dynatrace.com`.
+- If anything in this prompt is ambiguous, ask before assuming.
+
+Begin with step 1 (pressure-test). Wait for my response.
+```
+
+---
+
+## After the design pass — switching to Claude Code (Step 9)
+
+Once Claude has produced the spec, open this repo in Claude Code and paste:
+
+```
+Read designing_dynatrace_apps_with_claude.md and the design spec I just pasted
+below. Then:
+
+1. Summarize your understanding of the app in 5 bullets.
+2. Propose a file-by-file plan for Phase 1 (scaffold + global filters +
+   one fully-wired tab). Do not write code yet.
+3. Wait for my approval before implementing.
+
+Use the dt-dql-essentials and dt-app-dashboards skills from .claude/skills
+before writing any DQL or dashboard JSON.
+
+——— DESIGN SPEC ———
+«paste the full markdown spec produced by Claude in step 8»
+```
+
+Then iterate Phase 1 → review in `dt-app dev` → commit → Phase 2, and so on.
+
+---
+
+## Tips
+
+- **Use Sonnet first.** Switch to Opus only if ideation is generic or the spec
+  step is producing fluff.
+- **Start a fresh chat for the spec.** The mockup-iteration chat accumulates
+  noise; the spec chat should start clean with the final mockup pasted in.
+- **Keep the customer name and tenant URL in the prompt.** Claude will route
+  MCP calls accordingly and will pattern-match industry-appropriate placeholder
+  data.
+- **Anchor with example dashboards.** If the customer has existing dashboard
+  JSON or screenshots, paste them — Claude pattern-matches well from concrete
+  examples.

--- a/skills/dt-app-appengine/SKILL.md
+++ b/skills/dt-app-appengine/SKILL.md
@@ -1,0 +1,507 @@
+# AppEngine  Development Skill
+
+Create and Improve AppEngine application for the Dynatrace SaaS Platform 
+
+Skill to compliment the Dynatrace Platform 
+
+Dynatrace Solutions Engineers and Customer Success Engineers for building a custom Dynatrace App for a customer or internal use.
+
+It assumes you have not yet run dt-app dev before, but already know Dynatrace and can read DQL. You have a tenant you can develop against and want a polished, customer-presentable app rather than a throwaway prototype.
+
+## What This Skill Covers
+
+- Creating and Running an AppEngine application on the Dynatrace SaaS Platform
+- Building a simple AppEngine application that can execute DQL queries and display results
+
+## Prerequisites
+
+Most friction in this workflow comes from skipped setup and authentication issues. Complete all prerequisites now so the later steps stay focused on the app, not the environment.
+
+### 1. A Dynatrace Tenant You Can Develop Against
+
+**Tenant endpoint:** You need a SaaS tenant URL of the form `https://tenantid.apps.dynatrace.com`. This is the AppEngine endpoint, not the classic `.live.dynatrace.com` URL. Confirm you can log in to the Apps UI before continuing.
+
+**Recommended usage:** For customer work, use a customer sandbox or non-prod tenant if one exists. If you are developing for a production tenant directly, get written approval from the customer first.
+
+### 2. Node.js and npm
+
+Install Node.js LTS (20.x or newer). Verify the installation with:
+
+```bash
+node --version
+npm --version
+```
+
+### 3. dtctl: The Dynatrace Observability CLI
+
+**What it is for:** `dtctl` is the official Dynatrace CLI built for both humans and AI agents. You will use it for querying, deploying, and managing your app from the command line.
+
+- Blog: https://www.dynatrace.com/news/blog/dtctl-the-dynatrace-observability-cli-thats-built-for-ai-agents-and-humans/
+- GitHub: https://github.com/dynatrace-oss/dtctl
+
+Install following the GitHub README, then authenticate against your tenant:
+
+```bash
+dtctl auth login
+```
+
+Verify with a simple DQL query:
+
+```bash
+dtctl dql "fetch dt.davis.problems | limit 5"
+```
+
+If that returns rows, you are good.
+
+### 4. Dynatrace MCP Server
+
+The Dynatrace MCP (Model Context Protocol) server is what lets Claude talk to your tenant. This is the **single most important prerequisite** for this whole workflow.
+
+- Docs: https://docs.dynatrace.com/docs/dynatrace-intelligence/dynatrace-intelligence-integrations/dynatrace-mcp#connect-to-the-mcp-server
+- Hub listing: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/
+
+Follow the connection instructions for both clients:
+
+- **Claude client:** connect the MCP server through Settings and Connectors, then provide the tenant URL and OAuth token or use the OAuth flow if supported.
+- **Claude Code:** configure the MCP server in your Claude Code MCP settings using the same tenant context.
+
+**Validate the connection** by asking Claude in either client:
+
+> "Use the Dynatrace MCP to fetch the last 5 problems from my tenant."
+
+If it returns real data, you are wired up.
+
+### 5. Dynatrace for AI Skills
+
+A growing library of agentic skills (DQL essentials, dashboard generation patterns, brand assets, lessons learned) maintained by Dynatrace.
+
+Repo: https://github.com/Dynatrace/dynatrace-for-ai
+
+Clone it locally. You will point Claude Code at specific skill files during the build, particularly the DQL ones, which prevent common rookie mistakes.
+
+### 6. Dynatrace AppEngine and the dt-app CLI
+
+AppEngine is the framework for building custom Dynatrace apps. The `dt-app` CLI scaffolds, runs, and deploys them.
+
+- Blog: https://www.dynatrace.com/news/blog/appengine-custom-apps-for-data-insights/
+- Platform docs: https://docs.dynatrace.com/docs/platform/appengine
+- Developer portal: https://developer.dynatrace.com/
+
+Install the CLI globally, then verify:
+
+```bash
+npm install -g @dynatrace-sdk/dt-app
+dt-app --version
+```
+
+### 7. Claude Access
+
+You need both of the following:
+
+- **Claude client:** use it for ideation, visual mockups, and specification writing. Sonnet handles most work well; switch to Opus only when you need deeper reasoning.
+- **Claude Code:** use it in the terminal for real implementation against the customer tenant.
+
+### 8. A GitHub Repo
+
+Create an empty private repo for your app. You will connect your local app folder to it during scaffolding. Customer apps should live in customer-specific repos with appropriate access controls.
+
+### 9. Dynatrace Brand Assets (Optional but Recommended)
+
+If your app will be customer-facing or demoed in front of leadership, ground the visual design in real Dynatrace brand colors and typography rather than letting Claude guess.
+
+Brand portal: https://dynatrace.sharepoint.com/sites/MarketingComms/SiteAssets
+
+You can paste these primary brand colors directly into your prompts:
+
+| Palette | Hex Values |
+|---------|-----------|
+| Blues | `#1C5BE5` `#4635D6` `#1497FF` `#54C8E9` |
+| Purples | `#B23BE4` `#6C3AD6` `#6F2EA8` |
+| Greens | `#BDDF28` `#73BE28` |
+| Pink | `#E436FF` |
+
+Telling Claude to use these from step 1 produces a modern React-style UI rather than the default Strato look.
+
+---
+
+## The Process at a Glance
+
+The full workflow has nine steps. Steps 1 through 8 happen in the Claude client. Step 9 happens in Claude Code in the terminal.
+
+| Step | Surface | Activity |
+|------|---------|----------|
+| 1 | Claude client | First-pass ideation and rough scope |
+| 2 | Claude client | Re-ideate and pressure-test the idea |
+| 3 | Claude client | Build the 80% design prompt |
+| 4 | Claude client | Create the visual mockup with placeholder data |
+| 5 | Claude client | Refine the mockup |
+| 6 | Claude client | Wire the mockup to real customer data via Dynatrace MCP |
+| 7 | Claude client | Tweak the design to 90–95% completion |
+| 8 | Claude client | Generate the complete design specification |
+| 9 | Claude Code | Scaffold, build, and deploy the real app |
+
+---
+
+## Step 01 — Ideate with Claude (First Pass)
+
+**How to start the conversation:** Open a new chat in the Claude client. Start with Sonnet. State the problem you are trying to solve, not the app you think you want to build.
+
+| Less effective | More effective |
+|---|---|
+| "I want to build a dashboard for cascade risk." | "Our customer's TechOps team cannot see when one application's failure is about to take down five others, and they are reacting instead of getting ahead." |
+
+**What to include in the prompt:** Name the customer, the problem, the current workaround, the data sources you know about, and what you want Claude to help you think through — the most valuable angles, the primary user per angle, the data sources needed, and the killer view.
+
+**How to evaluate the options:** Let Claude propose three or four directions. Do not commit yet. Push back on weak ones. Ask "what would this look like for a managing director vs an SRE?" if the audience is unclear.
+
+**When to switch models:** Switch to Opus if Sonnet is producing generic ideas that could apply to any customer, and you suspect there is a sharper angle you have not surfaced.
+
+✅ **Done when:** You have one direction picked, and you can write a single sentence describing what the app is for and who it is for.
+
+---
+
+## Step 02 — Re-Ideate with Claude
+
+**Why a second chat matters:** Start a fresh chat. The first chat has accumulated meandering context. The second chat gets the polished version of the idea.
+
+**How to pressure-test the idea:** Paste your one-sentence app description from step 1 and ask Claude to pressure-test it. Ask for the strongest version, the weakest assumption, and the one thing that, if you get it wrong, makes the whole app useless to the user.
+
+**Why this step saves time:** This step catches the failure mode where step 1 produced an idea that sounded good but does not survive contact with reality. If Claude finds a hole, fix the idea. If it does not, move on.
+
+✅ **Done when:** You have a refined one-paragraph description of the app, with named users, named decisions, and named data sources.
+
+---
+
+## Step 03 — Provide an 80% Complete Design Prompt
+
+This is the prompt that produces your first visual mockup. Spend real time on it. The quality of everything downstream is set here.
+
+**Prompt structure:** Include these sections:
+
+- **Context:** who the customer is, what the app is for, who the primary users are, and what decisions the app helps them make.
+- **Scope:** the number of tabs or views, what each one is for, the data sources involved, drill-down behavior, and refresh cadence expectations.
+- **Visual direction:** theme, brand colors, tone, density, and design inspiration.
+- **Out of scope:** features you do not want Claude to design yet.
+- **Task:** build a non-functional visual mockup as an HTML artifact using realistic placeholder data, with emphasis on layout, information density, and visual hierarchy.
+
+✅ **Done when:** You have submitted the prompt and Claude is producing an artifact.
+
+---
+
+## Step 04 — Visual Mockup in the Claude Client
+
+Claude will render an HTML artifact in the right pane. Look at it for a full minute before you react. Ask yourself:
+
+- Does the information hierarchy match the user's decision flow? What the user needs first should be biggest and topmost.
+- Is the density right? Too sparse means the user will scroll for everything. Too dense means they cannot find anything.
+- Does it look like a product, or does it look like a wireframe?
+
+Take a screenshot. Save it. You will compare future iterations against this one.
+
+✅ **Done when:** You have a mockup that is at least 70% of what you want.
+
+---
+
+## Step 05 — Refine the Design and Re-Render
+
+Iterate with restraint at this stage. Avoid over-refining a mockup that will change once real data is added.
+
+**Productive refinements now:** re-arranging major sections, adding or removing whole views, changing the visual approach, establishing patterns.
+
+**Ignore for now:** specific tile copy, exact color shades, spacing tweaks, icon choices. Bank those for step 7.
+
+✅ **Done when:** The structure is right and the visual direction is locked, even if the data is fake and the polish is rough.
+
+---
+
+## Step 06 — Wire the Mockup to Real Customer Data
+
+This is where the mockup becomes useful. You will ask Claude to query the customer tenant via the Dynatrace MCP, then update the mockup with real data and real DQL.
+
+**Prepare before you prompt:**
+
+- **Guardrails on data sources:** tell Claude exactly which data sources are in scope and which are not.
+- **Example dashboards:** provide existing JSON exports and screenshots when available so Claude can pattern-match.
+- **Specific locator hints:** name the workload, service, problem ID, application CI, or other entity that should anchor the queries.
+- **Expected data shape:** describe the ranges or patterns you expect so Claude can detect when query output is clearly wrong.
+
+**Prompting pattern:**
+
+```
+Use the Dynatrace MCP connected to [tenant URL] to query real data for this mockup.
+Follow the guardrails.
+Write the DQL query that produces each tile's data.
+Execute the query.
+Update the mockup with real returned values.
+Show both the DQL and the values.
+Stop if a query returns nothing or unexpected results — do not invent placeholder data.
+```
+
+Claude will iterate. Expect 5 to 15 MCP tool calls per mockup tile. When it finishes, you have a mockup that is visually styled the way you want and powered by real data. The DQL queries it produced are reusable in step 8.
+
+✅ **Done when:** Every tile in the mockup shows real numbers from the customer tenant, and you have the DQL for each one captured in the chat.
+
+---
+
+## Step 07 — Tweak to 90–95% of Your Liking
+
+Refine tile copy, color accents, callout boxes, badge styling, chip styling, section headers, empty states, hover behavior, and stat-bar numbers.
+
+> **Important:** Stop at about 95% complete. The last layer of polish belongs in the real app build with real components. Any visual polish you do in the HTML mockup gets thrown away anyway.
+
+✅ **Done when:** You would be comfortable showing this mockup to the customer as a "here is what we are going to build" reference.
+
+---
+
+## Step 08 — Generate the Complete Design Specification
+
+This is the most valuable artifact in the entire process. The spec is what makes the difference between a 30-iteration messy build and a 5-to-15-iteration clean build in step 9.
+
+**Write the specification:** Keep Claude in the same chat so it retains the full design and data context. Ask for a complete implementation-ready specification for Claude Code. Require the spec to define:
+
+- AppEngine structure, permissions, and intents
+- Routing and reusable React components
+- Global filters and their DQL impact
+- DQL per tile with real field names (not pseudocode)
+- Drill-down behavior and AppEngine intent contracts
+- Build phases with acceptance criteria
+- Known limitations and future work
+
+**Review the specification critically.** Push back on anything vague. For example:
+
+> "Section 7.4 is too abstract — expand it with the tile-by-tile breakdown including DQL."
+
+Iterate until the spec is something you would be proud to hand to a colleague.
+
+✅ **Done when:** The spec is comprehensive enough that someone who was not in this chat could read it and know exactly what to build.
+
+---
+
+## Step 09 — Scaffold, Build, and Deploy with Claude Code
+
+Now you switch surfaces. Open your terminal. Open Claude Code. Have your spec from step 8 ready to paste.
+
+### 9a. Scaffold the App
+
+Bootstrap the project and verify the dev server runs:
+
+```bash
+dt-app init
+dt-app dev
+```
+
+Set up a clean versioning workflow before heavy iteration begins. Connect the project to your GitHub repo.
+
+**Force a plan-first workflow** by pasting the complete spec, then adding:
+
+```
+Before you write any code, summarize the current state and propose a
+file-by-file plan for me to approve before you start implementing.
+```
+
+> **Why this matters:** Without the plan-first instruction, Claude Code will sometimes generate the whole app in one pass. If its mental model diverges from yours, you have to throw it all out. The plan-first pattern is cheap insurance.
+
+### 9b. Approve the Plan
+
+Read the plan. Push back on anything that looks wrong. Ask for justifications where the plan is non-obvious. When the plan is right, tell Claude Code to proceed with Phase 1.
+
+### 9c. Iterate Phase by Phase
+
+Have Claude Code implement one phase at a time. After each phase:
+
+```bash
+dt-app dev
+```
+
+- Load the app in the customer tenant
+- Check the phase acceptance criteria
+- Test drill-down and intent behavior
+- Commit to GitHub before moving to the next phase
+
+**Load the right DQL skills early.** Pull `dt-dql-essentials` and `dt-dql-lessons-learned` from the Dynatrace for AI Skills repo into the Claude Code context before any DQL gets written. The lessons-learned file catches common errors:
+
+- Inline math inside `makeTimeseries` aggregation parameters
+- Missing curly braces on multi-aggregation `summarize`
+- Span duration unit confusion (nanoseconds vs microseconds)
+
+### 9d. Deploy to the Customer Tenant
+
+```bash
+# Build the production bundle
+dt-app build
+
+# Upload via dtctl
+dtctl app deploy
+
+# Tag the GitHub commit with the deployed version
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+The customer can now open the app directly in their tenant.
+
+---
+
+## The Polish vs. Prototype Decision
+
+### When you can skip the full spec
+
+Skip step 8 and go straight to Claude Code from a mockup if:
+
+- You are exploring whether an idea is worth pursuing
+- The audience is internal and just needs to see the concept
+- You are willing to throw it all away
+
+### When you should not skip it
+
+Do not skip the full spec if:
+
+- The app will be shown to a customer
+- The app will be deployed to a customer tenant
+- You will need to maintain or extend it
+- More than one person will work on it
+
+| Without a spec | With a spec |
+|---|---|
+| 20–40 Claude Code iterations | 5–15 Claude Code iterations |
+| Higher risk of wrong direction | Token cost usually recovered during build |
+
+---
+
+## What a Complete Spec Looks Like
+
+A finished design spec for a Dynatrace App runs **800 to 1,500 lines of markdown**. It includes:
+
+- Purpose and overview, with named users and the north star metric
+- Tab structure, with route keys and what each tab is for
+- Visual design system including color palette, typography, component anatomy diagrams, badge variants, and hover behavior
+- Global filter bar definition with the DQL impact of each filter
+- Global data contracts including cached lookup queries and loading behavior
+- Drill-down architecture using direct deep links and AppEngine intent contracts
+- Tab-by-tab specification including stats bars, hero tiles, supporting tiles, and DQL for each
+- DQL reference appendix with critical rules embedded as comments and inline notes
+- App configuration including `app.config.json`, intent registration, and permissions
+- Component library to build first
+- Known limitations and future work
+- Acceptance criteria per tab
+
+---
+
+## Appendix A: Anonymized Example Specification
+
+The following is a lightly anonymized excerpt from a real spec for a multi-tab observability intelligence app. The full spec runs about 1,400 lines of markdown. This excerpt shows the structure and level of detail to aim for.
+
+```
+# [App Name] — Implementation Specification
+
+## 1. Purpose and Overview
+## 2. Tab Structure
+## 3. Visual Design System
+## 4. Global Filter Bar
+## 5. Global Data Contracts
+## 6. Drill-Down Architecture
+## 7. Tab-by-Tab Specification
+## 8. Critical DQL Rules
+## 9. App Configuration
+## 10. Component Library
+## 11. Known Limitations
+## 12. Acceptance Criteria
+```
+
+> **The bar:** Real hex codes. Real DQL with the actual field names. Real permission strings. Real acceptance criteria with real numbers. That is the bar.
+
+---
+
+## Appendix B: Troubleshooting Cheat Sheet
+
+### The Dynatrace MCP returns "tool not found" in Claude
+
+The MCP server is not actually connected. Re-check Settings and Connectors in the Claude client, or your MCP config file in Claude Code. Restart the client after reconfiguring.
+
+### dt-app dev will not load in the tenant
+
+Confirm you are logged in to the tenant in the same browser session, confirm the tenant URL uses `.apps.dynatrace.com`, and confirm the app permissions match what your DQL requires.
+
+### DQL queries return nothing
+
+```sql
+-- First check the time range
+-- Then verify field names, especially dt.* prefixes
+-- Use describe to inspect available fields:
+describe [entity-type]
+```
+
+### makeTimeseries errors with cryptic messages
+
+This is often caused by inline math inside the aggregation. Compute raw values first, then convert in a subsequent step:
+
+```sql
+// WRONG: inline math in aggregation parameter
+makeTimeseries avg(duration / 1000000)
+
+// CORRECT: raw aggregation first, then convert
+makeTimeseries avg_ns = avg(duration)
+| fieldsAdd avg_ms = avg_ns[] / 1000000
+```
+
+### Multi-aggregation summarize errors
+
+Wrap multiple aggregations in curly braces:
+
+```sql
+// WRONG
+summarize total = count(), failures = countIf(error == true)
+
+// CORRECT
+summarize {total = count(), failures = countIf(error == true)}, by: {span.name}
+```
+
+### Claude Code wants to write the whole app in one pass
+
+Require it to summarize the current state and propose a file-by-file plan before implementing.
+
+### The app looks like every other Strato app
+
+Add the brand palette earlier in the workflow so Claude has explicit visual direction from step 1.
+
+### You are dozens of iterations into a build and it still is not right
+
+Stop and generate the full specification before continuing. If the app proves valuable enough to keep, you can retrofit a spec by asking Claude to generate one from the current codebase.
+
+---
+
+## Appendix C: The CLAUDE.md Prompt Pattern
+
+Using a `CLAUDE.md` file at the repo root persists project-level guidance. Claude Code reads this file automatically on every invocation.
+
+```markdown
+# CLAUDE.md
+
+## Goal
+One sentence describing what this project is.
+
+## Guardrails
+- Coding principles
+- Propose a plan before writing code
+- Justify key architectural decisions
+
+## Tasks
+1. Current Phase 1 implementation priority
+2. Next priority
+3. ...
+
+## Persistence
+Update this file during long sessions and before compactification.
+Reflect the current state of completed and in-progress work.
+
+## Documentation
+See README.md for setup and usage. Keep it current as the app evolves.
+
+## Notifications
+Send completion notices to: [your-slack-channel or email]
+```
+
+This pattern helps Claude Code stay aligned across long builds and compactification events. It is optional, but it pays off quickly on projects that span more than a few sessions.
+
+---
+
+*Last updated: May 2026 · Send corrections and improvements to David.Beran@dynatrace.com*

--- a/skills/dt-app-appengine/SKILL.md
+++ b/skills/dt-app-appengine/SKILL.md
@@ -1,509 +1,146 @@
-# AppEngine  Development Skill
+---
+name: dt-app-appengine
+description: >-
+  Scaffold, build, and deploy Dynatrace AppEngine apps using the dt-app CLI and dtctl.
+  Covers project init, the plan-first build loop, phase-by-phase iteration against a
+  customer tenant, and gated deployment. Use this skill when the user wants to create a
+  custom Dynatrace App, run `dt-app init/dev/build`, or deploy to a `*.apps.dynatrace.com`
+  tenant.
+  Trigger: "build a Dynatrace app", "AppEngine app", "dt-app init", "scaffold a Dynatrace
+  App", "deploy to dynatrace tenant".
+  Do NOT use for: dashboards (use dt-app-dashboards), notebooks (use dt-app-notebooks),
+  pure DQL authoring (use dt-dql-essentials), or classic-to-Smartscape migration (use
+  dt-migration). For the human-facing ideation-to-spec process that produces the design
+  this skill implements, see WORKFLOW.md in this folder.
+license: Apache-2.0
+---
 
+# Dynatrace AppEngine App Skill
 
-| Name | Description | License |
-|---|---|---|
-| dt-app-appengine | Skill for building AppEngine for the Dynatrace Platform apps using the dt-app CLI and Claude Code, from ideation to deployment. | Apache-2.0 
+Scaffold, build, and deploy a custom Dynatrace App on AppEngine using the `dt-app` CLI and `dtctl`. This skill assumes a design specification already exists; the upstream ideation, mockup, and spec-writing process is documented in `WORKFLOW.md` in this folder.
 
+## When to use
 
-Create and Improve AppEngine application for the Dynatrace SaaS Platform 
+Use when the user wants to:
 
-Skill to compliment the Dynatrace Platform 
+- Initialize a new AppEngine project (`dt-app init`)
+- Run an app locally against a customer tenant (`dt-app dev`)
+- Build and deploy a production bundle (`dt-app build`, `dtctl app deploy`)
+- Iterate phase-by-phase against an implementation spec
 
-Dynatrace Solutions Engineers and Customer Success Engineers for building a custom Dynatrace App for a customer or internal use.
+Skip when:
 
-It assumes you have not yet run dt-app dev before, but already know Dynatrace and can read DQL. You have a tenant you can develop against and want a polished, customer-presentable app rather than a throwaway prototype.
+- The user only wants to write or fix a DQL query → `dt-dql-essentials`
+- The user wants to create a dashboard → `dt-app-dashboards`
+- The user wants to create a notebook → `dt-app-notebooks`
 
-## What This Skill Covers
+## Hard rules
 
-- Creating and Running an AppEngine application on the Dynatrace SaaS Platform
-- Building a simple AppEngine application that can execute DQL queries and display results
+1. **Plan before code.** Never generate the full app in one pass. After receiving the spec, summarize current state and propose a file-by-file plan. Wait for explicit user approval before writing implementation code.
+2. **One phase at a time.** Implement → verify acceptance criteria → commit → next phase. Do not start phase N+1 before phase N is verified by the user.
+3. **Load DQL skills before writing DQL.** Pull `dt-dql-essentials` into context before generating any query. Defer DQL pitfall handling to that skill.
+4. **Deploy requires explicit confirmation.** Never run `dtctl app deploy` without the user explicitly authorizing the deploy in the current turn. Authorization in a previous session does not carry over.
+5. **Do not invent data.** If a tenant query returns nothing or unexpected results, surface it. Do not substitute placeholder values in a real-data build.
 
-## Prerequisites
+## Pre-flight check
 
-Most friction in this workflow comes from skipped setup and authentication issues. Complete all prerequisites now so the later steps stay focused on the app, not the environment.
-
-### 1. A Dynatrace Tenant You Can Develop Against
-
-**Tenant endpoint:** You need a SaaS tenant URL of the form `https://tenantid.apps.dynatrace.com`. This is the AppEngine endpoint, not the classic `.live.dynatrace.com` URL. Confirm you can log in to the Apps UI before continuing.
-
-**Recommended usage:** For customer work, use a customer sandbox or non-prod tenant if one exists. If you are developing for a production tenant directly, get written approval from the customer first.
-
-### 2. Node.js and npm
-
-Install Node.js LTS (20.x or newer). Verify the installation with:
+Before scaffolding, run this once and report any failures back to the user:
 
 ```bash
-node --version
+node --version      # require >= 20.x LTS
 npm --version
+dt-app --version
+dtctl --version
+dtctl auth status
 ```
 
-### 3. dtctl: The Dynatrace Observability CLI
-
-**What it is for:** `dtctl` is the official Dynatrace CLI built for both humans and AI agents. You will use it for querying, deploying, and managing your app from the command line.
-
-- Blog: https://www.dynatrace.com/news/blog/dtctl-the-dynatrace-observability-cli-thats-built-for-ai-agents-and-humans/
-- GitHub: https://github.com/dynatrace-oss/dtctl
-
-Install following the GitHub README, then authenticate against your tenant:
-
-```bash
-dtctl auth login
-```
-
-Verify with a simple DQL query:
-
-```bash
-dtctl dql "fetch dt.davis.problems | limit 5"
-```
-
-If that returns rows, you are good.
-
-### 4. Dynatrace MCP Server
-
-The Dynatrace MCP (Model Context Protocol) server is what lets Claude talk to your tenant. This is the **single most important prerequisite** for this whole workflow.
-
-- Docs: https://docs.dynatrace.com/docs/dynatrace-intelligence/dynatrace-intelligence-integrations/dynatrace-mcp#connect-to-the-mcp-server
-- Hub listing: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/
-
-Follow the connection instructions for both clients:
-
-- **Claude client:** connect the MCP server through Settings and Connectors, then provide the tenant URL and OAuth token or use the OAuth flow if supported.
-- **Claude Code:** configure the MCP server in your Claude Code MCP settings using the same tenant context.
-
-**Validate the connection** by asking Claude in either client:
-
-> "Use the Dynatrace MCP to fetch the last 5 problems from my tenant."
-
-If it returns real data, you are wired up.
-
-### 5. Dynatrace for AI Skills
-
-A growing library of agentic skills (DQL essentials, dashboard generation patterns, brand assets, lessons learned) maintained by Dynatrace.
-
-Repo: https://github.com/Dynatrace/dynatrace-for-ai
-
-Clone it locally. You will point Claude Code at specific skill files during the build, particularly the DQL ones, which prevent common rookie mistakes.
-
-### 6. Dynatrace AppEngine and the dt-app CLI
-
-AppEngine is the framework for building custom Dynatrace apps. The `dt-app` CLI scaffolds, runs, and deploys them.
-
-- Blog: https://www.dynatrace.com/news/blog/appengine-custom-apps-for-data-insights/
-- Platform docs: https://docs.dynatrace.com/docs/platform/appengine
-- Developer portal: https://developer.dynatrace.com/
-
-Install the CLI globally, then verify:
+If `dt-app` is missing:
 
 ```bash
 npm install -g @dynatrace-sdk/dt-app
-dt-app --version
 ```
 
-### 7. Claude Access
+If `dtctl` is not authenticated, ask the user to run `dtctl auth login` themselves — it is an interactive flow. Do not try to drive it.
 
-You need both of the following:
+Verify tenant access with a trivial query:
 
-- **Claude client:** use it for ideation, visual mockups, and specification writing. Sonnet handles most work well; switch to Opus only when you need deeper reasoning.
-- **Claude Code:** use it in the terminal for real implementation against the customer tenant.
-
-### 8. A GitHub Repo
-
-Create an empty private repo for your app. You will connect your local app folder to it during scaffolding. Customer apps should live in customer-specific repos with appropriate access controls.
-
-### 9. Dynatrace Brand Assets (Optional but Recommended)
-
-If your app will be customer-facing or demoed in front of leadership, ground the visual design in real Dynatrace brand colors and typography rather than letting Claude guess.
-
-Brand portal: https://dynatrace.sharepoint.com/sites/MarketingComms/SiteAssets
-
-You can paste these primary brand colors directly into your prompts:
-
-| Palette | Hex Values |
-|---------|-----------|
-| Blues | `#1C5BE5` `#4635D6` `#1497FF` `#54C8E9` |
-| Purples | `#B23BE4` `#6C3AD6` `#6F2EA8` |
-| Greens | `#BDDF28` `#73BE28` |
-| Pink | `#E436FF` |
-
-Telling Claude to use these from step 1 produces a modern React-style UI rather than the default Strato look.
-
----
-
-## The Process at a Glance
-
-The full workflow has nine steps. Steps 1 through 8 happen in the Claude client. Step 9 happens in Claude Code in the terminal.
-
-| Step | Surface | Activity |
-|------|---------|----------|
-| 1 | Claude client | First-pass ideation and rough scope |
-| 2 | Claude client | Re-ideate and pressure-test the idea |
-| 3 | Claude client | Build the 80% design prompt |
-| 4 | Claude client | Create the visual mockup with placeholder data |
-| 5 | Claude client | Refine the mockup |
-| 6 | Claude client | Wire the mockup to real customer data via Dynatrace MCP |
-| 7 | Claude client | Tweak the design to 90–95% completion |
-| 8 | Claude client | Generate the complete design specification |
-| 9 | Claude Code | Scaffold, build, and deploy the real app |
-
----
-
-## Step 01 — Ideate with Claude (First Pass)
-
-**How to start the conversation:** Open a new chat in the Claude client. Start with Sonnet. State the problem you are trying to solve, not the app you think you want to build.
-
-| Less effective | More effective |
-|---|---|
-| "I want to build a dashboard for cascade risk." | "Our customer's TechOps team cannot see when one application's failure is about to take down five others, and they are reacting instead of getting ahead." |
-
-**What to include in the prompt:** Name the customer, the problem, the current workaround, the data sources you know about, and what you want Claude to help you think through — the most valuable angles, the primary user per angle, the data sources needed, and the killer view.
-
-**How to evaluate the options:** Let Claude propose three or four directions. Do not commit yet. Push back on weak ones. Ask "what would this look like for a managing director vs an SRE?" if the audience is unclear.
-
-**When to switch models:** Switch to Opus if Sonnet is producing generic ideas that could apply to any customer, and you suspect there is a sharper angle you have not surfaced.
-
-✅ **Done when:** You have one direction picked, and you can write a single sentence describing what the app is for and who it is for.
-
----
-
-## Step 02 — Re-Ideate with Claude
-
-**Why a second chat matters:** Start a fresh chat. The first chat has accumulated meandering context. The second chat gets the polished version of the idea.
-
-**How to pressure-test the idea:** Paste your one-sentence app description from step 1 and ask Claude to pressure-test it. Ask for the strongest version, the weakest assumption, and the one thing that, if you get it wrong, makes the whole app useless to the user.
-
-**Why this step saves time:** This step catches the failure mode where step 1 produced an idea that sounded good but does not survive contact with reality. If Claude finds a hole, fix the idea. If it does not, move on.
-
-✅ **Done when:** You have a refined one-paragraph description of the app, with named users, named decisions, and named data sources.
-
----
-
-## Step 03 — Provide an 80% Complete Design Prompt
-
-This is the prompt that produces your first visual mockup. Spend real time on it. The quality of everything downstream is set here.
-
-**Prompt structure:** Include these sections:
-
-- **Context:** who the customer is, what the app is for, who the primary users are, and what decisions the app helps them make.
-- **Scope:** the number of tabs or views, what each one is for, the data sources involved, drill-down behavior, and refresh cadence expectations.
-- **Visual direction:** theme, brand colors, tone, density, and design inspiration.
-- **Out of scope:** features you do not want Claude to design yet.
-- **Task:** build a non-functional visual mockup as an HTML artifact using realistic placeholder data, with emphasis on layout, information density, and visual hierarchy.
-
-✅ **Done when:** You have submitted the prompt and Claude is producing an artifact.
-
----
-
-## Step 04 — Visual Mockup in the Claude Client
-
-Claude will render an HTML artifact in the right pane. Look at it for a full minute before you react. Ask yourself:
-
-- Does the information hierarchy match the user's decision flow? What the user needs first should be biggest and topmost.
-- Is the density right? Too sparse means the user will scroll for everything. Too dense means they cannot find anything.
-- Does it look like a product, or does it look like a wireframe?
-
-Take a screenshot. Save it. You will compare future iterations against this one.
-
-✅ **Done when:** You have a mockup that is at least 70% of what you want.
-
----
-
-## Step 05 — Refine the Design and Re-Render
-
-Iterate with restraint at this stage. Avoid over-refining a mockup that will change once real data is added.
-
-**Productive refinements now:** re-arranging major sections, adding or removing whole views, changing the visual approach, establishing patterns.
-
-**Ignore for now:** specific tile copy, exact color shades, spacing tweaks, icon choices. Bank those for step 7.
-
-✅ **Done when:** The structure is right and the visual direction is locked, even if the data is fake and the polish is rough.
-
----
-
-## Step 06 — Wire the Mockup to Real Customer Data
-
-This is where the mockup becomes useful. You will ask Claude to query the customer tenant via the Dynatrace MCP, then update the mockup with real data and real DQL.
-
-**Prepare before you prompt:**
-
-- **Guardrails on data sources:** tell Claude exactly which data sources are in scope and which are not.
-- **Example dashboards:** provide existing JSON exports and screenshots when available so Claude can pattern-match.
-- **Specific locator hints:** name the workload, service, problem ID, application CI, or other entity that should anchor the queries.
-- **Expected data shape:** describe the ranges or patterns you expect so Claude can detect when query output is clearly wrong.
-
-**Prompting pattern:**
-
-```
-Use the Dynatrace MCP connected to [tenant URL] to query real data for this mockup.
-Follow the guardrails.
-Write the DQL query that produces each tile's data.
-Execute the query.
-Update the mockup with real returned values.
-Show both the DQL and the values.
-Stop if a query returns nothing or unexpected results — do not invent placeholder data.
+```bash
+dtctl dql "fetch dt.davis.problems | limit 1"
 ```
 
-Claude will iterate. Expect 5 to 15 MCP tool calls per mockup tile. When it finishes, you have a mockup that is visually styled the way you want and powered by real data. The DQL queries it produced are reusable in step 8.
+A non-error response confirms the tenant is reachable.
 
-✅ **Done when:** Every tile in the mockup shows real numbers from the customer tenant, and you have the DQL for each one captured in the chat.
+## The build loop
 
----
-
-## Step 07 — Tweak to 90–95% of Your Liking
-
-Refine tile copy, color accents, callout boxes, badge styling, chip styling, section headers, empty states, hover behavior, and stat-bar numbers.
-
-> **Important:** Stop at about 95% complete. The last layer of polish belongs in the real app build with real components. Any visual polish you do in the HTML mockup gets thrown away anyway.
-
-✅ **Done when:** You would be comfortable showing this mockup to the customer as a "here is what we are going to build" reference.
-
----
-
-## Step 08 — Generate the Complete Design Specification
-
-This is the most valuable artifact in the entire process. The spec is what makes the difference between a 30-iteration messy build and a 5-to-15-iteration clean build in step 9.
-
-**Write the specification:** Keep Claude in the same chat so it retains the full design and data context. Ask for a complete implementation-ready specification for Claude Code. Require the spec to define:
-
-- AppEngine structure, permissions, and intents
-- Routing and reusable React components
-- Global filters and their DQL impact
-- DQL per tile with real field names (not pseudocode)
-- Drill-down behavior and AppEngine intent contracts
-- Build phases with acceptance criteria
-- Known limitations and future work
-
-**Review the specification critically.** Push back on anything vague. For example:
-
-> "Section 7.4 is too abstract — expand it with the tile-by-tile breakdown including DQL."
-
-Iterate until the spec is something you would be proud to hand to a colleague.
-
-✅ **Done when:** The spec is comprehensive enough that someone who was not in this chat could read it and know exactly what to build.
-
----
-
-## Step 09 — Scaffold, Build, and Deploy with Claude Code
-
-Now you switch surfaces. Open your terminal. Open Claude Code. Have your spec from step 8 ready to paste.
-
-### 9a. Scaffold the App
-
-Bootstrap the project and verify the dev server runs:
+### 1. Scaffold
 
 ```bash
 dt-app init
-dt-app dev
 ```
 
-Set up a clean versioning workflow before heavy iteration begins. Connect the project to your GitHub repo.
-
-**Force a plan-first workflow** by pasting the complete spec, then adding:
-
-```
-Before you write any code, summarize the current state and propose a
-file-by-file plan for me to approve before you start implementing.
-```
-
-> **Why this matters:** Without the plan-first instruction, Claude Code will sometimes generate the whole app in one pass. If its mental model diverges from yours, you have to throw it all out. The plan-first pattern is cheap insurance.
-
-### 9b. Approve the Plan
-
-Read the plan. Push back on anything that looks wrong. Ask for justifications where the plan is non-obvious. When the plan is right, tell Claude Code to proceed with Phase 1.
-
-### 9c. Iterate Phase by Phase
-
-Have Claude Code implement one phase at a time. After each phase:
+After init, connect the project to the user's GitHub repo. The user supplies the remote URL — do not guess one. Then:
 
 ```bash
 dt-app dev
 ```
 
-- Load the app in the customer tenant
-- Check the phase acceptance criteria
-- Test drill-down and intent behavior
-- Commit to GitHub before moving to the next phase
+Confirm the dev server loads in the customer tenant browser before continuing. The tenant URL must be `https://<tenantid>.apps.dynatrace.com`, not `.live.dynatrace.com`.
 
-**Load the right DQL skills early.** Pull `dt-dql-essentials` and `dt-dql-lessons-learned` from the Dynatrace for AI Skills repo into the Claude Code context before any DQL gets written. The lessons-learned file catches common errors:
+### 2. Propose the plan
 
-- Inline math inside `makeTimeseries` aggregation parameters
-- Missing curly braces on multi-aggregation `summarize`
-- Span duration unit confusion (nanoseconds vs microseconds)
+Reference the design spec, then produce:
 
-### 9d. Deploy to the Customer Tenant
+- A file-by-file plan grouped by phase
+- Acceptance criteria per phase (lifted from the spec)
+- Open questions back to the user
+
+Wait for approval. Do not begin implementation until the plan is approved.
+
+### 3. Implement phase N
+
+- Generate code for the files in phase N only.
+- For any tile or view requiring DQL: load `dt-dql-essentials` first.
+- After implementation, ask the user to run `dt-app dev` and verify against the phase acceptance criteria. Also ask them to test drill-down and intent behavior if the phase covers them.
+- Commit the phase to GitHub before moving on. Use a descriptive message tied to the phase.
+
+### 4. Repeat until all phases pass acceptance.
+
+### 5. Deploy (gated)
+
+Only after the user explicitly authorizes deployment in the current turn:
 
 ```bash
-# Build the production bundle
 dt-app build
-
-# Upload via dtctl
 dtctl app deploy
-
-# Tag the GitHub commit with the deployed version
 git tag v0.1.0 && git push origin v0.1.0
 ```
 
-The customer can now open the app directly in their tenant.
+Confirm the app is visible and loadable in the customer tenant before declaring the deploy complete.
 
----
+## Troubleshooting
 
-## The Polish vs. Prototype Decision
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| MCP "tool not found" in Claude | MCP server not connected | Reconnect via Settings → Connectors; restart client |
+| `dt-app dev` won't load in tenant | Wrong tenant URL or session | Confirm `.apps.dynatrace.com` URL; confirm browser is logged in to the same tenant; confirm app permissions match the DQL |
+| DQL returns nothing | Wrong time range or field name | Use `describe <entity-type>`; verify `dt.*` prefixes; defer to `dt-dql-essentials` |
+| Claude wants to write the whole app | Plan-first rule violated | Stop; restate hard rule #1 and re-propose a plan |
+| App looks generic / default Strato | No brand direction supplied | See the brand palette section in `WORKFLOW.md` |
+| Many iterations, app still wrong | No spec — drifting | Stop; generate a spec from the current code per `WORKFLOW.md` Step 8, then resume |
 
-### When you can skip the full spec
+For DQL-specific pitfalls (`makeTimeseries` inline math, multi-aggregation `summarize`, span duration units, etc.) defer to `dt-dql-essentials`.
 
-Skip step 8 and go straight to Claude Code from a mockup if:
+## Companion skills
 
-- You are exploring whether an idea is worth pursuing
-- The audience is internal and just needs to see the concept
-- You are willing to throw it all away
+- `dt-dql-essentials` — required before any DQL is written
+- `dt-app-dashboards` — if the app embeds or generates dashboards
+- `dt-app-notebooks` — if the app embeds or generates notebooks
+- `dt-migration` — if porting from a classic Gen2 entity model
 
-### When you should not skip it
+## See also
 
-Do not skip the full spec if:
-
-- The app will be shown to a customer
-- The app will be deployed to a customer tenant
-- You will need to maintain or extend it
-- More than one person will work on it
-
-| Without a spec | With a spec |
-|---|---|
-| 20–40 Claude Code iterations | 5–15 Claude Code iterations |
-| Higher risk of wrong direction | Token cost usually recovered during build |
-
----
-
-## What a Complete Spec Looks Like
-
-A finished design spec for a Dynatrace App runs **800 to 1,500 lines of markdown**. It includes:
-
-- Purpose and overview, with named users and the north star metric
-- Tab structure, with route keys and what each tab is for
-- Visual design system including color palette, typography, component anatomy diagrams, badge variants, and hover behavior
-- Global filter bar definition with the DQL impact of each filter
-- Global data contracts including cached lookup queries and loading behavior
-- Drill-down architecture using direct deep links and AppEngine intent contracts
-- Tab-by-tab specification including stats bars, hero tiles, supporting tiles, and DQL for each
-- DQL reference appendix with critical rules embedded as comments and inline notes
-- App configuration including `app.config.json`, intent registration, and permissions
-- Component library to build first
-- Known limitations and future work
-- Acceptance criteria per tab
-
----
-
-## Appendix A: Anonymized Example Specification
-
-The following is a lightly anonymized excerpt from a real spec for a multi-tab observability intelligence app. The full spec runs about 1,400 lines of markdown. This excerpt shows the structure and level of detail to aim for.
-
-```
-# [App Name] — Implementation Specification
-
-## 1. Purpose and Overview
-## 2. Tab Structure
-## 3. Visual Design System
-## 4. Global Filter Bar
-## 5. Global Data Contracts
-## 6. Drill-Down Architecture
-## 7. Tab-by-Tab Specification
-## 8. Critical DQL Rules
-## 9. App Configuration
-## 10. Component Library
-## 11. Known Limitations
-## 12. Acceptance Criteria
-```
-
-> **The bar:** Real hex codes. Real DQL with the actual field names. Real permission strings. Real acceptance criteria with real numbers. That is the bar.
-
----
-
-## Appendix B: Troubleshooting Cheat Sheet
-
-### The Dynatrace MCP returns "tool not found" in Claude
-
-The MCP server is not actually connected. Re-check Settings and Connectors in the Claude client, or your MCP config file in Claude Code. Restart the client after reconfiguring.
-
-### dt-app dev will not load in the tenant
-
-Confirm you are logged in to the tenant in the same browser session, confirm the tenant URL uses `.apps.dynatrace.com`, and confirm the app permissions match what your DQL requires.
-
-### DQL queries return nothing
-
-```sql
--- First check the time range
--- Then verify field names, especially dt.* prefixes
--- Use describe to inspect available fields:
-describe [entity-type]
-```
-
-### makeTimeseries errors with cryptic messages
-
-This is often caused by inline math inside the aggregation. Compute raw values first, then convert in a subsequent step:
-
-```sql
-// WRONG: inline math in aggregation parameter
-makeTimeseries avg(duration / 1000000)
-
-// CORRECT: raw aggregation first, then convert
-makeTimeseries avg_ns = avg(duration)
-| fieldsAdd avg_ms = avg_ns[] / 1000000
-```
-
-### Multi-aggregation summarize errors
-
-Wrap multiple aggregations in curly braces:
-
-```sql
-// WRONG
-summarize total = count(), failures = countIf(error == true)
-
-// CORRECT
-summarize {total = count(), failures = countIf(error == true)}, by: {span.name}
-```
-
-### Claude Code wants to write the whole app in one pass
-
-Require it to summarize the current state and propose a file-by-file plan before implementing.
-
-### The app looks like every other Strato app
-
-Add the brand palette earlier in the workflow so Claude has explicit visual direction from step 1.
-
-### You are dozens of iterations into a build and it still is not right
-
-Stop and generate the full specification before continuing. If the app proves valuable enough to keep, you can retrofit a spec by asking Claude to generate one from the current codebase.
-
----
-
-## Appendix C: The CLAUDE.md Prompt Pattern
-
-Using a `CLAUDE.md` file at the repo root persists project-level guidance. Claude Code reads this file automatically on every invocation.
-
-```markdown
-# CLAUDE.md
-
-## Goal
-One sentence describing what this project is.
-
-## Guardrails
-- Coding principles
-- Propose a plan before writing code
-- Justify key architectural decisions
-
-## Tasks
-1. Current Phase 1 implementation priority
-2. Next priority
-3. ...
-
-## Persistence
-Update this file during long sessions and before compactification.
-Reflect the current state of completed and in-progress work.
-
-## Documentation
-See README.md for setup and usage. Keep it current as the app evolves.
-
-## Notifications
-Send completion notices to: [your-slack-channel or email]
-```
-
-This pattern helps Claude Code stay aligned across long builds and compactification events. It is optional, but it pays off quickly on projects that span more than a few sessions.
+- `WORKFLOW.md` (this folder) — the 9-step human workflow from ideation to spec
+- AppEngine platform docs: https://docs.dynatrace.com/docs/platform/appengine
+- Developer portal: https://developer.dynatrace.com/
+- dtctl: https://github.com/dynatrace-oss/dtctl
+- Dynatrace MCP server: https://docs.dynatrace.com/docs/dynatrace-intelligence/dynatrace-intelligence-integrations/dynatrace-mcp

--- a/skills/dt-app-appengine/SKILL.md
+++ b/skills/dt-app-appengine/SKILL.md
@@ -47,7 +47,9 @@ Skip when:
 Before scaffolding, run this once and report any failures back to the user:
 
 ```bash
-node --version      # require >= 20.x LTS
+node --version      # require >= NodeJS version 24. 
+
+
 npm --version
 dt-app --version
 dtctl --version

--- a/skills/dt-app-appengine/SKILL.md
+++ b/skills/dt-app-appengine/SKILL.md
@@ -1,5 +1,11 @@
 # AppEngine  Development Skill
 
+
+| Name | Description | License |
+|---|---|---|
+| dt-app-appengine | Skill for building AppEngine for the Dynatrace Platform apps using the dt-app CLI and Claude Code, from ideation to deployment. | Apache-2.0 
+
+
 Create and Improve AppEngine application for the Dynatrace SaaS Platform 
 
 Skill to compliment the Dynatrace Platform 
@@ -501,7 +507,3 @@ Send completion notices to: [your-slack-channel or email]
 ```
 
 This pattern helps Claude Code stay aligned across long builds and compactification events. It is optional, but it pays off quickly on projects that span more than a few sessions.
-
----
-
-*Last updated: May 2026 · Send corrections and improvements to David.Beran@dynatrace.com*

--- a/skills/dt-app-appengine/WORKFLOW.md
+++ b/skills/dt-app-appengine/WORKFLOW.md
@@ -1,0 +1,344 @@
+# Workflow: From Idea to Deployed Dynatrace App
+
+This is the human-facing process for designing and shipping a custom Dynatrace App on AppEngine. It covers ideation, mockup, real-data wiring, and specification writing — everything that happens *before* you scaffold the app in Claude Code.
+
+The technical scaffold, build, and deploy mechanics live in `SKILL.md`. This file is the design judgement that makes a customer-presentable app instead of a throwaway prototype.
+
+## Audience
+
+Dynatrace Solutions Engineers and Customer Success Engineers building a custom Dynatrace App for a customer or internal use. Assumes you know Dynatrace, can read DQL, have a tenant to develop against, and want a polished result rather than a one-off prototype.
+
+---
+
+## Prerequisites (human-side)
+
+The technical CLI prerequisites (`node`, `npm`, `dt-app`, `dtctl`, MCP server) are checked automatically when you start the skill — see `SKILL.md`. The setup that is not just CLI tooling:
+
+### 1. A Dynatrace tenant you can develop against
+
+**Tenant endpoint:** SaaS tenant URL of the form `https://tenantid.apps.dynatrace.com`. This is the AppEngine endpoint, not the classic `.live.dynatrace.com` URL. Confirm you can log in to the Apps UI before continuing.
+
+**Recommended usage:** For customer work, use a customer sandbox or non-prod tenant if one exists. If you are developing directly against production, get written approval from the customer first.
+
+### 2. The Dynatrace MCP server
+
+The MCP (Model Context Protocol) server is what lets Claude talk to your tenant. This is the **single most important prerequisite** for the design phase.
+
+- Docs: https://docs.dynatrace.com/docs/dynatrace-intelligence/dynatrace-intelligence-integrations/dynatrace-mcp
+- Hub listing: https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/
+
+Follow the connection instructions for both clients:
+
+- **Claude client:** connect through Settings → Connectors, providing the tenant URL and OAuth credentials.
+- **Claude Code:** configure the MCP server in your MCP settings using the same tenant context.
+
+**Validate the connection** by asking Claude in either client:
+
+> "Use the Dynatrace MCP to fetch the last 5 problems from my tenant."
+
+If it returns real data, you are wired up.
+
+### 3. Claude client and Claude Code
+
+- **Claude client:** ideation, visual mockups, specification writing. Sonnet handles most of this well; switch to Opus when you need deeper reasoning.
+- **Claude Code:** terminal-based implementation against the customer tenant.
+
+### 4. A GitHub repo
+
+Empty, private, customer-scoped if this is customer work. You'll connect your local app folder to it during scaffolding.
+
+### 5. The Dynatrace for AI skills repo
+
+A growing library of agentic skills (DQL essentials, dashboard patterns, observability domain skills, lessons learned). Clone it locally so you can point Claude Code at specific skill files during the build — particularly the DQL ones, which prevent common errors.
+
+Repo: https://github.com/Dynatrace/dynatrace-for-ai
+
+### 6. Dynatrace brand assets (optional, recommended)
+
+If your app is customer-facing or will be demoed to leadership, ground the visual design in real Dynatrace brand colors and typography rather than letting Claude guess.
+
+Brand portal (internal): https://dynatrace.sharepoint.com/sites/MarketingComms/SiteAssets
+
+Primary brand palette to paste directly into prompts:
+
+| Palette | Hex Values |
+|---------|-----------|
+| Blues | `#1C5BE5` `#4635D6` `#1497FF` `#54C8E9` |
+| Purples | `#B23BE4` `#6C3AD6` `#6F2EA8` |
+| Greens | `#BDDF28` `#73BE28` |
+| Pink | `#E436FF` |
+
+Telling Claude to use these from step 1 produces a modern React-style UI rather than the default Strato look.
+
+---
+
+## The process at a glance
+
+The full workflow has nine steps. Steps 1 through 8 happen in the Claude client. Step 9 happens in Claude Code in the terminal and is driven by `SKILL.md`.
+
+| Step | Surface | Activity |
+|------|---------|----------|
+| 1 | Claude client | First-pass ideation and rough scope |
+| 2 | Claude client | Re-ideate and pressure-test the idea |
+| 3 | Claude client | Build the 80% design prompt |
+| 4 | Claude client | Create the visual mockup with placeholder data |
+| 5 | Claude client | Refine the mockup |
+| 6 | Claude client | Wire the mockup to real customer data via Dynatrace MCP |
+| 7 | Claude client | Tweak the design to 90–95% completion |
+| 8 | Claude client | Generate the complete design specification |
+| 9 | Claude Code | Scaffold, build, and deploy the real app (see `SKILL.md`) |
+
+---
+
+## Step 01 — Ideate with Claude (First Pass)
+
+**How to start:** Open a new chat in the Claude client. Start with Sonnet. State the problem you are trying to solve, not the app you think you want to build.
+
+| Less effective | More effective |
+|---|---|
+| "I want to build a dashboard for cascade risk." | "Our customer's TechOps team cannot see when one application's failure is about to take down five others, and they are reacting instead of getting ahead." |
+
+**What to include in the prompt:** Name the customer, the problem, the current workaround, the data sources you know about, and what you want Claude to help you think through — the most valuable angles, the primary user per angle, the data sources needed, and the killer view.
+
+**How to evaluate the options:** Let Claude propose three or four directions. Do not commit yet. Push back on weak ones. Ask "what would this look like for a managing director vs an SRE?" if the audience is unclear.
+
+**When to switch models:** Switch to Opus if Sonnet is producing generic ideas that could apply to any customer, and you suspect there is a sharper angle you have not surfaced.
+
+**Done when:** You have one direction picked, and you can write a single sentence describing what the app is for and who it is for.
+
+---
+
+## Step 02 — Re-Ideate with Claude
+
+**Why a second chat matters:** Start a fresh chat. The first chat has accumulated meandering context. The second chat gets the polished version of the idea.
+
+**How to pressure-test the idea:** Paste your one-sentence app description from step 1 and ask Claude to pressure-test it. Ask for the strongest version, the weakest assumption, and the one thing that, if you get it wrong, makes the whole app useless to the user.
+
+**Why this step saves time:** It catches the failure mode where step 1 produced an idea that sounded good but does not survive contact with reality. If Claude finds a hole, fix the idea. If it does not, move on.
+
+**Done when:** You have a refined one-paragraph description of the app, with named users, named decisions, and named data sources.
+
+---
+
+## Step 03 — Provide an 80% Complete Design Prompt
+
+This is the prompt that produces your first visual mockup. Spend real time on it. The quality of everything downstream is set here.
+
+**Prompt structure:** Include these sections:
+
+- **Context:** who the customer is, what the app is for, who the primary users are, and what decisions the app helps them make.
+- **Scope:** the number of tabs or views, what each one is for, the data sources involved, drill-down behavior, and refresh cadence expectations.
+- **Visual direction:** theme, brand colors, tone, density, and design inspiration.
+- **Out of scope:** features you do not want Claude to design yet.
+- **Task:** build a non-functional visual mockup as an HTML artifact using realistic placeholder data, with emphasis on layout, information density, and visual hierarchy.
+
+**Done when:** You have submitted the prompt and Claude is producing an artifact.
+
+---
+
+## Step 04 — Visual Mockup in the Claude Client
+
+Claude will render an HTML artifact in the right pane. Look at it for a full minute before you react. Ask yourself:
+
+- Does the information hierarchy match the user's decision flow? What the user needs first should be biggest and topmost.
+- Is the density right? Too sparse means the user will scroll for everything. Too dense means they cannot find anything.
+- Does it look like a product, or does it look like a wireframe?
+
+Take a screenshot. Save it. You will compare future iterations against this one.
+
+**Done when:** You have a mockup that is at least 70% of what you want.
+
+---
+
+## Step 05 — Refine the Design and Re-Render
+
+Iterate with restraint at this stage. Avoid over-refining a mockup that will change once real data is added.
+
+**Productive refinements now:** re-arranging major sections, adding or removing whole views, changing the visual approach, establishing patterns.
+
+**Ignore for now:** specific tile copy, exact color shades, spacing tweaks, icon choices. Bank those for step 7.
+
+**Done when:** The structure is right and the visual direction is locked, even if the data is fake and the polish is rough.
+
+---
+
+## Step 06 — Wire the Mockup to Real Customer Data
+
+This is where the mockup becomes useful. You will ask Claude to query the customer tenant via the Dynatrace MCP, then update the mockup with real data and real DQL.
+
+**Prepare before you prompt:**
+
+- **Guardrails on data sources:** tell Claude exactly which data sources are in scope and which are not.
+- **Example dashboards:** provide existing JSON exports and screenshots when available so Claude can pattern-match.
+- **Specific locator hints:** name the workload, service, problem ID, application CI, or other entity that should anchor the queries.
+- **Expected data shape:** describe the ranges or patterns you expect so Claude can detect when query output is clearly wrong.
+
+**Prompting pattern:**
+
+```
+Use the Dynatrace MCP connected to [tenant URL] to query real data for this mockup.
+Follow the guardrails.
+Write the DQL query that produces each tile's data.
+Execute the query.
+Update the mockup with real returned values.
+Show both the DQL and the values.
+Stop if a query returns nothing or unexpected results — do not invent placeholder data.
+```
+
+Claude will iterate. Expect 5 to 15 MCP tool calls per mockup tile. When it finishes, you have a mockup that is visually styled the way you want and powered by real data. The DQL queries it produced are reusable in step 8.
+
+**Done when:** Every tile in the mockup shows real numbers from the customer tenant, and you have the DQL for each one captured in the chat.
+
+---
+
+## Step 07 — Tweak to 90–95% of Your Liking
+
+Refine tile copy, color accents, callout boxes, badge styling, chip styling, section headers, empty states, hover behavior, and stat-bar numbers.
+
+> **Important:** Stop at about 95% complete. The last layer of polish belongs in the real app build with real components. Any visual polish you do in the HTML mockup gets thrown away anyway.
+
+**Done when:** You would be comfortable showing this mockup to the customer as a "here is what we are going to build" reference.
+
+---
+
+## Step 08 — Generate the Complete Design Specification
+
+This is the most valuable artifact in the entire process. The spec is what makes the difference between a 30-iteration messy build and a 5-to-15-iteration clean build in step 9.
+
+**Write the specification:** Keep Claude in the same chat so it retains the full design and data context. Ask for a complete implementation-ready specification for Claude Code. Require the spec to define:
+
+- AppEngine structure, permissions, and intents
+- Routing and reusable React components
+- Global filters and their DQL impact
+- DQL per tile with real field names (not pseudocode)
+- Drill-down behavior and AppEngine intent contracts
+- Build phases with acceptance criteria
+- Known limitations and future work
+
+**Review the specification critically.** Push back on anything vague. For example:
+
+> "Section 7.4 is too abstract — expand it with the tile-by-tile breakdown including DQL."
+
+Iterate until the spec is something you would be proud to hand to a colleague.
+
+**Done when:** The spec is comprehensive enough that someone who was not in this chat could read it and know exactly what to build.
+
+---
+
+## Step 09 — Scaffold, Build, and Deploy with Claude Code
+
+Switch surfaces: open your terminal and open Claude Code with your spec from step 8 ready to paste.
+
+From here, `SKILL.md` takes over. It enforces:
+
+- A pre-flight check of `node`, `dt-app`, `dtctl`, and tenant auth.
+- A plan-first contract: Claude Code must summarize state and propose a file-by-file plan before writing code.
+- Phase-by-phase iteration with acceptance criteria and GitHub commits between phases.
+- A gated deploy step that requires your explicit authorization before `dtctl app deploy` runs.
+
+Paste your spec into Claude Code and let the skill drive.
+
+---
+
+## The Polish vs. Prototype Decision
+
+### When you can skip the full spec
+
+Skip step 8 and go straight to Claude Code from a mockup if:
+
+- You are exploring whether an idea is worth pursuing
+- The audience is internal and just needs to see the concept
+- You are willing to throw it all away
+
+### When you should not skip it
+
+Do not skip the full spec if:
+
+- The app will be shown to a customer
+- The app will be deployed to a customer tenant
+- You will need to maintain or extend it
+- More than one person will work on it
+
+| Without a spec | With a spec |
+|---|---|
+| 20–40 Claude Code iterations | 5–15 Claude Code iterations |
+| Higher risk of wrong direction | Token cost usually recovered during build |
+
+---
+
+## What a Complete Spec Looks Like
+
+A finished design spec for a Dynatrace App runs **800 to 1,500 lines of markdown**. It includes:
+
+- Purpose and overview, with named users and the north star metric
+- Tab structure, with route keys and what each tab is for
+- Visual design system including color palette, typography, component anatomy diagrams, badge variants, and hover behavior
+- Global filter bar definition with the DQL impact of each filter
+- Global data contracts including cached lookup queries and loading behavior
+- Drill-down architecture using direct deep links and AppEngine intent contracts
+- Tab-by-tab specification including stats bars, hero tiles, supporting tiles, and DQL for each
+- DQL reference appendix with critical rules embedded as comments and inline notes
+- App configuration including `app.config.json`, intent registration, and permissions
+- Component library to build first
+- Known limitations and future work
+- Acceptance criteria per tab
+
+---
+
+## Appendix A: Anonymized Example Specification
+
+The following is a lightly anonymized excerpt from a real spec for a multi-tab observability intelligence app. The full spec runs about 1,400 lines of markdown. This excerpt shows the structure and level of detail to aim for.
+
+```
+# [App Name] — Implementation Specification
+
+## 1. Purpose and Overview
+## 2. Tab Structure
+## 3. Visual Design System
+## 4. Global Filter Bar
+## 5. Global Data Contracts
+## 6. Drill-Down Architecture
+## 7. Tab-by-Tab Specification
+## 8. Critical DQL Rules
+## 9. App Configuration
+## 10. Component Library
+## 11. Known Limitations
+## 12. Acceptance Criteria
+```
+
+> **The bar:** Real hex codes. Real DQL with the actual field names. Real permission strings. Real acceptance criteria with real numbers. That is the bar.
+
+---
+
+## Appendix B: The CLAUDE.md Prompt Pattern
+
+Using a `CLAUDE.md` file at the repo root persists project-level guidance. Claude Code reads this file automatically on every invocation.
+
+```markdown
+# CLAUDE.md
+
+## Goal
+One sentence describing what this project is.
+
+## Guardrails
+- Coding principles
+- Propose a plan before writing code
+- Justify key architectural decisions
+
+## Tasks
+1. Current Phase 1 implementation priority
+2. Next priority
+3. ...
+
+## Persistence
+Update this file during long sessions and before compactification.
+Reflect the current state of completed and in-progress work.
+
+## Documentation
+See README.md for setup and usage. Keep it current as the app evolves.
+
+## Notifications
+Send completion notices to: [your-slack-channel or email]
+```
+
+This pattern helps Claude Code stay aligned across long builds and compactification events. It is optional, but it pays off quickly on projects that span more than a few sessions.


### PR DESCRIPTION
Dynatrace AppEngine App Skill
Scaffold, build, and deploy a custom Dynatrace App on AppEngine using the dt-app CLI and dtctl. This skill assumes a design specification already exists; the upstream ideation, mockup, and spec-writing process is documented in [WORKFLOW.md](WORKFLOW.md)in this folder
