### PR TITLE
chore: upgrade GitHub Actions to Node 24 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

Upgrades outdated GitHub Actions to Node 24 compatible versions, fixing Node 20 deprecation warnings on GitHub-hosted runners.

**Related:** ASDY-27739

## Test plan

- [ ] CI passes on this PR
- [ ] No Node 20 deprecation warnings in workflow runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)