### PR TITLE
feat(plugin): added claude and cursor plugin configs, including simple MCP config with env-var auth

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,12 @@
 {
   "name": "dynatrace-for-ai",
-  "owner": {
-    "name": "Dynatrace"
-  },
+  "description": "Dynatrace observability skills and knowledge packages for AI coding agents.",
+  "owner": { "name": "Dynatrace" },
   "plugins": [
     {
       "name": "dynatrace",
       "description": "Dynatrace observability skills for AI agents.",
-      "source": "./plugins/dynatrace"
+      "source": "./"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "dynatrace",
+  "version": "0.2.0",
+  "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
+  "author": { "name": "Dynatrace" },
+  "homepage": "https://www.dynatrace.com",
+  "repository": "https://github.com/Dynatrace/dynatrace-for-ai",
+  "license": "Apache-2.0",
+  "mcpServers": "./.mcp.json"
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "dynatrace",
+  "version": "0.2.0",
+  "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
+  "author": { "name": "Dynatrace" },
+  "homepage": "https://www.dynatrace.com",
+  "repository": "https://github.com/Dynatrace/dynatrace-for-ai",
+  "license": "Apache-2.0"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "dynatrace": {
       "type": "http",
-      "url": "${DT_ENVIRONMENT:-urlmissing}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
+      "url": "${DT_ENVIRONMENT}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
       "headers": {
         "Authorization": "Bearer ${DT_PLATFORM_TOKEN}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "dynatrace": {
+      "type": "http",
+      "url": "${DT_ENVIRONMENT:-urlmissing}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
+      "headers": {
+        "Authorization": "Bearer ${DT_PLATFORM_TOKEN}"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ claude plugin marketplace add dynatrace/dynatrace-for-ai
 claude plugin install dynatrace@dynatrace-for-ai
 ```
 
+The plugin includes the Dynatrace MCP server. Set these environment variables before starting Claude Code to connect it to your environment:
+
+```bash
+export DT_ENVIRONMENT=https://<env>.apps.dynatrace.com   # e.g. https://abc12345.apps.dynatrace.com
+export DT_PLATFORM_TOKEN=<your-platform-token>
+```
+
 Update with `claude plugin marketplace update && claude plugin update dynatrace@dynatrace-for-ai`.
 
 ### Manual
@@ -47,7 +54,7 @@ Or install the dtctl skill with dtctl itself: `dtctl skills install`
 
 ### Dynatrace MCP Server
 
-The **[Dynatrace MCP server](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server)** provides Dynatrace API access via MCP. Use this if your agent supports MCP natively.
+The **[Dynatrace MCP server](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server)** provides Dynatrace API access via MCP. The Claude Code plugin bundles the MCP server configuration automatically — just set `DT_ENVIRONMENT` and `DT_PLATFORM_TOKEN` as shown above. For other agents that support MCP natively, see the [MCP server docs](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server).
 
 ## Skills
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "dynatrace": {
+      "url": "${env:DT_ENVIRONMENT}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:DT_PLATFORM_TOKEN}"
+      }
+    }
+  }
+}

--- a/plugins/dynatrace/.claude-plugin/plugin.json
+++ b/plugins/dynatrace/.claude-plugin/plugin.json
@@ -1,5 +1,0 @@
-{
-  "name": "dynatrace",
-  "version": "0.2.0",
-  "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access."
-}

--- a/plugins/dynatrace/skills/dt-alerting
+++ b/plugins/dynatrace/skills/dt-alerting
@@ -1,1 +1,0 @@
-../../../skills/dt-alerting

--- a/plugins/dynatrace/skills/dt-app-dashboards
+++ b/plugins/dynatrace/skills/dt-app-dashboards
@@ -1,1 +1,0 @@
-../../../skills/dt-app-dashboards

--- a/plugins/dynatrace/skills/dt-app-notebooks
+++ b/plugins/dynatrace/skills/dt-app-notebooks
@@ -1,1 +1,0 @@
-../../../skills/dt-app-notebooks

--- a/plugins/dynatrace/skills/dt-dql-essentials
+++ b/plugins/dynatrace/skills/dt-dql-essentials
@@ -1,1 +1,0 @@
-../../../skills/dt-dql-essentials

--- a/plugins/dynatrace/skills/dt-js-runtime
+++ b/plugins/dynatrace/skills/dt-js-runtime
@@ -1,1 +1,0 @@
-../../../skills/dt-js-runtime

--- a/plugins/dynatrace/skills/dt-migration
+++ b/plugins/dynatrace/skills/dt-migration
@@ -1,1 +1,0 @@
-../../../skills/dt-migration

--- a/plugins/dynatrace/skills/dt-obs-android
+++ b/plugins/dynatrace/skills/dt-obs-android
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-android

--- a/plugins/dynatrace/skills/dt-obs-aws
+++ b/plugins/dynatrace/skills/dt-obs-aws
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-aws

--- a/plugins/dynatrace/skills/dt-obs-azure
+++ b/plugins/dynatrace/skills/dt-obs-azure
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-azure

--- a/plugins/dynatrace/skills/dt-obs-flutter
+++ b/plugins/dynatrace/skills/dt-obs-flutter
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-flutter

--- a/plugins/dynatrace/skills/dt-obs-frontends
+++ b/plugins/dynatrace/skills/dt-obs-frontends
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-frontends

--- a/plugins/dynatrace/skills/dt-obs-gcp
+++ b/plugins/dynatrace/skills/dt-obs-gcp
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-gcp

--- a/plugins/dynatrace/skills/dt-obs-genai
+++ b/plugins/dynatrace/skills/dt-obs-genai
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-genai

--- a/plugins/dynatrace/skills/dt-obs-hosts
+++ b/plugins/dynatrace/skills/dt-obs-hosts
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-hosts

--- a/plugins/dynatrace/skills/dt-obs-ios-sdk
+++ b/plugins/dynatrace/skills/dt-obs-ios-sdk
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-ios-sdk

--- a/plugins/dynatrace/skills/dt-obs-kubernetes
+++ b/plugins/dynatrace/skills/dt-obs-kubernetes
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-kubernetes

--- a/plugins/dynatrace/skills/dt-obs-log-semantic-mapping
+++ b/plugins/dynatrace/skills/dt-obs-log-semantic-mapping
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-log-semantic-mapping

--- a/plugins/dynatrace/skills/dt-obs-logs
+++ b/plugins/dynatrace/skills/dt-obs-logs
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-logs

--- a/plugins/dynatrace/skills/dt-obs-predictive-analytics
+++ b/plugins/dynatrace/skills/dt-obs-predictive-analytics
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-predictive-analytics

--- a/plugins/dynatrace/skills/dt-obs-problems
+++ b/plugins/dynatrace/skills/dt-obs-problems
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-problems

--- a/plugins/dynatrace/skills/dt-obs-react-native
+++ b/plugins/dynatrace/skills/dt-obs-react-native
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-react-native

--- a/plugins/dynatrace/skills/dt-obs-services
+++ b/plugins/dynatrace/skills/dt-obs-services
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-services

--- a/plugins/dynatrace/skills/dt-obs-tracing
+++ b/plugins/dynatrace/skills/dt-obs-tracing
@@ -1,1 +1,0 @@
-../../../skills/dt-obs-tracing

--- a/plugins/dynatrace/skills/dt-platform-costs
+++ b/plugins/dynatrace/skills/dt-platform-costs
@@ -1,1 +1,0 @@
-../../../skills/dt-platform-costs

--- a/plugins/dynatrace/skills/dt-sec-insights
+++ b/plugins/dynatrace/skills/dt-sec-insights
@@ -1,1 +1,0 @@
-../../../skills/dt-sec-insights

--- a/plugins/dynatrace/skills/dt-sec-semantic-mapping
+++ b/plugins/dynatrace/skills/dt-sec-semantic-mapping
@@ -1,1 +1,0 @@
-../../../skills/dt-sec-semantic-mapping

--- a/tests/test-structure.sh
+++ b/tests/test-structure.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Test: Validate structural consistency between skills/, plugin symlinks, and marketplace.json.
+# Test: Validate structural consistency between skills/, plugin manifests, and marketplace.json.
 #
 # Checks:
 #   1. Every skill dir has SKILL.md
-#   2. Every skill in skills/ has a corresponding symlink in plugins/dynatrace/skills/
-#   3. marketplace.json is valid and references the dynatrace plugin
-#   4. marketplace.json source uses ./ prefix
+#   2. .claude-plugin/plugin.json exists and has name "dynatrace"
+#   3. .cursor-plugin/plugin.json exists and has name "dynatrace"
+#   4. marketplace.json is valid, references the dynatrace plugin, source uses ./ prefix
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -14,7 +14,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 echo "=== test-structure.sh ==="
 
 python3 -c "
-import json, sys, os, re, pathlib
+import json, sys, pathlib
 
 root = pathlib.Path('$ROOT_DIR')
 errors = []
@@ -30,31 +30,23 @@ for d in sorted(skills_dir.iterdir()):
         else:
             errors.append(f'Skill dir {d.name}/ has no SKILL.md')
 
-# --- Check plugin skill symlinks ---
-plugin_skills_dir = root / 'plugins' / 'dynatrace' / 'skills'
-if plugin_skills_dir.exists():
-    linked_skills = set()
-    for entry in sorted(plugin_skills_dir.iterdir()):
-        if entry.name.startswith('dt-') and entry.is_symlink():
-            linked_skills.add(entry.name)
-
-    missing = sorted(disk_skills - linked_skills)
-    extra = sorted(linked_skills - disk_skills)
-    if missing:
-        errors.append(f'Plugin missing skill symlinks: {missing}')
-    if extra:
-        errors.append(f'Plugin has symlinks to non-existent skills: {extra}')
+# --- Check .claude-plugin/plugin.json ---
+claude_plugin_path = root / '.claude-plugin' / 'plugin.json'
+if not claude_plugin_path.exists():
+    errors.append('Missing .claude-plugin/plugin.json')
 else:
-    errors.append('Missing plugins/dynatrace/skills/ directory')
-
-# --- Check plugin.json ---
-plugin_json_path = root / 'plugins' / 'dynatrace' / '.claude-plugin' / 'plugin.json'
-if not plugin_json_path.exists():
-    errors.append('Missing plugins/dynatrace/.claude-plugin/plugin.json')
-else:
-    pj = json.loads(plugin_json_path.read_text())
+    pj = json.loads(claude_plugin_path.read_text())
     if pj.get('name') != 'dynatrace':
-        errors.append(f'plugin.json name is \"{pj.get(\"name\")}\" not \"dynatrace\"')
+        errors.append(f'.claude-plugin/plugin.json name is \"{pj.get(\"name\")}\" not \"dynatrace\"')
+
+# --- Check .cursor-plugin/plugin.json ---
+cursor_plugin_path = root / '.cursor-plugin' / 'plugin.json'
+if not cursor_plugin_path.exists():
+    errors.append('Missing .cursor-plugin/plugin.json')
+else:
+    pj = json.loads(cursor_plugin_path.read_text())
+    if pj.get('name') != 'dynatrace':
+        errors.append(f'.cursor-plugin/plugin.json name is \"{pj.get(\"name\")}\" not \"dynatrace\"')
 
 # --- Check marketplace.json ---
 mp_path = root / '.claude-plugin' / 'marketplace.json'
@@ -63,7 +55,7 @@ if not mp_path.exists():
 else:
     mp = json.loads(mp_path.read_text())
     plugins = mp.get('plugins', [])
-    dynatrace_plugin = next((plugin for plugin in plugins if plugin.get('name') == 'dynatrace'), None)
+    dynatrace_plugin = next((p for p in plugins if p.get('name') == 'dynatrace'), None)
     if dynatrace_plugin is None:
         errors.append('marketplace.json does not reference the \"dynatrace\" plugin')
     elif not dynatrace_plugin.get('source', '').startswith('./'):
@@ -74,7 +66,9 @@ if errors:
         print(f'FAIL: {e}', file=sys.stderr)
     sys.exit(1)
 
-print(f'  {len(disk_skills)} skills on disk, all linked in plugin')
+print(f'  {len(disk_skills)} skills on disk')
+print('  .claude-plugin/plugin.json valid')
+print('  .cursor-plugin/plugin.json valid')
 print('  marketplace.json valid')
 "
 


### PR DESCRIPTION
## Summary

- Restructures the repo to a single root-level layout with `.claude-plugin/` and `.cursor-plugin/` manifests (shared `skills/` directory)
- Bundles the Dynatrace MCP server in `plugin.json` via `.mcp.json`
- MCP config uses a plain `Authorization: Bearer ${DT_PLATFORM_TOKEN}` header
- Documents the required environment variables in the README

## How to connect to Dynatrace

Set environment variables before starting Claude Code:

```bash
export DT_ENVIRONMENT=http://<env>.apps.dynatrace.com   # e.g. abc12345
export DT_PLATFORM_TOKEN=<your-platform-token>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)