### PR TITLE
chore: add a link to Dynatrace MCP server docs in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Dynatrace Plugin
+
+This plugin includes skills as well as the Dynatrace MCP server for Dynatrace platform access.
+
+## Required setup for Dynatrace MCP Server
+
+Set these environment variables, e.g., in `~/.claude/settings.json` under `env`:
+
+- `DT_ENVIRONMENT` — your Dynatrace environment URL, e.g. `https://abc12345.apps.dynatrace.com` (Note: `https://` is required)
+- `DT_PLATFORM_TOKEN` — a platform token with at least MCP gateway scopes
+
+Consult the [Dynatrace MCP server docs
+](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for a full list of scopes required for using the MCP Server with a Platform Token.
+
+## Skills for Observability related questions
+
+Please use the included skills for observability related questions.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ export DT_ENVIRONMENT=https://<env>.apps.dynatrace.com   # e.g. https://abc12345
 export DT_PLATFORM_TOKEN=<your-platform-token>
 ```
 
+Please consult the [Dynatrace MCP server docs
+](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for a full list of scopes required for using the MCP Server with a Platform Token.
+
 Update with `claude plugin marketplace update && claude plugin update dynatrace@dynatrace-for-ai`.
 
 ### Manual


### PR DESCRIPTION
This should improve the situation for agents (e.g., claude) finding the correct setup for the Remote MCP, as well as related skills