### PR TITLE
feat(cursor-plugin): add displayName, keywords and logo

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,9 +1,12 @@
 {
   "name": "dynatrace",
+  "displayName": "Dynatrace",
   "version": "0.2.0",
   "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
   "author": { "name": "Dynatrace" },
   "homepage": "https://www.dynatrace.com",
   "repository": "https://github.com/Dynatrace/dynatrace-for-ai",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "keywords": ["dynatrace", "observability", "monitoring", "dql", "apm", "logs", "tracing"],
+  "logo": "Dynatrace_Logo_color_positive.png"
 }


### PR DESCRIPTION
## Summary

- Adds missing required fields to `.cursor-plugin/plugin.json` per the [cursor/plugin-template](https://github.com/cursor/plugin-template) spec
- `displayName`: `"Dynatrace"`
- `keywords`: observability-related terms
- `logo`: references `Dynatrace_Logo_color_positive.png` (added via #28)

## Notes

The logo file itself is added in #28 — this PR references the filename in advance.