### PR TITLE
fix(dt-dql-essentials): Smartscape node types are not a closed set

### DIFF
--- a/skills/dt-dql-essentials/SKILL.md
+++ b/skills/dt-dql-essentials/SKILL.md
@@ -268,7 +268,16 @@ Entity fields are scoped per type — `entity.id` does not exist. Use `smartscap
 | Process     | `dt.smartscape.process`      | `"PROCESS"`            |
 | K8s cluster | `dt.smartscape.k8s_cluster`  | `"K8S_CLUSTER"`        |
 
-Use `toSmartscapeId()` for ID conversion from strings (required!).
+**These four are examples, not the inventory.** A real environment carries well over a hundred node
+types, and the set is not closed — OpenPipeline can extract user-defined `CUSTOM_*` / `EXT_*` nodes.
+Discover them rather than working from a list:
+
+```dql
+smartscapeNodes "*" | dedup type | fields type
+```
+
+Use `toSmartscapeId()` for ID conversion from strings (required!). Nodes also carry `id_classic`, the
+classic entity ID, which is the bridge when migrating off `dt.entity.*`.
 
 → [references/smartscape-topology-navigation.md](references/smartscape-topology-navigation.md)
 

--- a/skills/dt-dql-essentials/references/smartscape-topology-navigation.md
+++ b/skills/dt-dql-essentials/references/smartscape-topology-navigation.md
@@ -50,6 +50,48 @@ smartscapeNodes "*"
 ```
 
 **CRITICAL:** Wrong node types return empty results (no error). Always validate for unfamiliar entities.
+For `CUSTOM_*` / `EXT_*` types an empty result is **ambiguous** — see "Custom node types" below.
+
+### Built-in types are broader than the examples above
+
+The built-in set is large — a single environment commonly carries well over a hundred types, most of
+them cloud-provider resources. Beyond the compute/Kubernetes types used as examples throughout this
+file, an environment typically also has `ACTIVEGATE`, `FRONTEND` (web and mobile, distinguished by
+`frontend.type`), `SYNTHETIC_LOCATION`, `BROWSER_MONITOR` / `BROWSER_MONITOR_STEP`, `HTTP_MONITOR` /
+`HTTP_MONITOR_STEP`, `CONTAINER`, `DISK`, and the `K8S_*` family. Run the discovery query above rather
+than working from any list — including this one.
+
+**`id_classic` bridges to classic entity IDs.** Nodes carry the classic ID alongside the Smartscape
+ID, which is what makes incremental migration off `dt.entity.*` possible:
+
+```dql
+smartscapeNodes "FRONTEND"
+| fields type, id, id_classic, name
+// id = FRONTEND-297F397B6836BBC8 , id_classic = APPLICATION-D9D748AC453CA045
+```
+
+### Custom node types
+
+Node types are not limited to the platform's built-in set. OpenPipeline can extract user-defined nodes
+and edges from ingested signals, so an environment may contain node types that exist nowhere in this
+reference.
+
+- Custom type names **must begin with `CUSTOM_` or `EXT_`** and must be unique in the environment.
+- They are queried exactly like built-in types: `smartscapeNodes "CUSTOM_APP_CONNECTOR"`.
+- Discover what actually exists rather than assuming:
+
+```dql
+smartscapeNodes "CUSTOM_*"
+| dedup type
+| fields type
+```
+
+**Empty result ≠ invalid type.** For a `CUSTOM_*` / `EXT_*` type, zero rows most often means the
+extraction pipeline has not produced a node yet — not that the type name is wrong. Distinguish the two
+by listing the types that do exist (query above) before concluding the name is bad.
+
+See [Smartscape node and edge extraction in OpenPipeline](https://docs.dynatrace.com/docs/platform/openpipeline/concepts/smartscape-extraction)
+for how these are produced. Configuring the pipeline is out of scope for this skill.
 
 ### Tags and Labels
 


### PR DESCRIPTION
## Problem

`skills/dt-dql-essentials` presents Smartscape node types as a fixed, platform-defined set. Three problems follow:

**1. The list reads as an inventory when it is a sample.** `SKILL.md` § *Entity & Smartscape Patterns* maps four types (HOST / SERVICE / PROCESS / K8S_CLUSTER). On one tenant, discovery returned **60 `AWS_*` types and 80 non-AWS types with both queries hitting their limits** — the real set is well past 140.

**2. Types an author needs are missing**, including `ACTIVEGATE`, `FRONTEND`, `SYNTHETIC_LOCATION`, `BROWSER_MONITOR(_STEP)`, `HTTP_MONITOR(_STEP)`, `CONTAINER`, `DISK` — and `id_classic`, the field carrying the classic entity ID that makes incremental migration off `dt.entity.*` possible. `id_classic` appears nowhere in the skill.

**3. No mention of user-defined `CUSTOM_*` / `EXT_*` types** produced by [OpenPipeline Smartscape extraction](https://docs.dynatrace.com/docs/platform/openpipeline/concepts/smartscape-extraction), now the supported way to model third-party objects as entities.

### The compounding problem

`references/smartscape-topology-navigation.md` says:

> **CRITICAL:** Wrong node types return empty results (no error). Always validate for unfamiliar entities.

Correct for built-in types, misleading for custom ones. An agent that queries a **valid** `CUSTOM_` type before its pipeline has produced a node gets zero rows and applies this rule to conclude the type name is wrong. The skill's own guidance produces the wrong inference — that's what makes this worth fixing rather than merely a gap.

## Change

Additive; nothing is retracted.

- `references/smartscape-topology-navigation.md` — qualifies the CRITICAL rule for `CUSTOM_*`/`EXT_*`; adds a "built-in types are broader than the examples" note with `id_classic`; adds a "Custom node types" section with the naming rule, the discovery query, and the empty-result-≠-invalid-type warning.
- `SKILL.md` — labels the four-row table as examples and points at the discovery query.

The four-row table stays. The durable fix is the redirection to discovery — it stops any list needing to stay exhaustive.

**Out of scope by design:** configuring OpenPipeline. This is a DQL skill; the reference links to the docs and stops.

## Verification — live tenant, 2026-08-11

| Query | Result |
|---|---|
| `smartscapeNodes "*" \| dedup type` | 140+ types across two limit-hitting queries |
| `smartscapeNodes "FRONTEND" \| fields type, id, id_classic, name` | `id_classic` returns `APPLICATION-*` beside `FRONTEND-*` |
| `smartscapeNodes "CUSTOM_*" \| dedup type` | valid, executes, **0 records, no error** — the exact ambiguity the new text warns about |

Every DQL snippet added to the skill was executed before commit.