### PR TITLE
fix(dt-dql-essentials): document fractional duration literals and the calendar-unit exception

### DIFF
--- a/skills/dt-dql-essentials/SKILL.md
+++ b/skills/dt-dql-essentials/SKILL.md
@@ -431,6 +431,11 @@ ______________________________________________________________________
 
 - Subtracting timestamps yields a duration: `timestamp - timestamp → duration`
 - Duration divided by duration yields a double: e.g. `2h / 1m` = `120.0`
+- Duration literals accept **fractional amounts on fixed-length units only** — `0.5h`, `0.25h`,
+  `1.5m`, `1.5s`, `1.5ms`, `1.5us` are all valid. The **calendar units `d` and `w` reject them**:
+  `0.25d` fails with `CALENDAR_DURATION_UNIT_NOT_SUPPORTED_FOR_FRACTIONAL_AMOUNT`, because a day or
+  week has no fixed nanosecond count (DST, leap seconds). Write `6h` rather than `0.25d`.
+  Note `1.5ns` truncates to `1` — nanosecond is the floor of the type's precision.
 - Scalar times duration yields a duration: e.g. `no_of_h * 1h → duration`
 - For extraction of time elements (hours, days of month, etc):
     - ✅ Use [time functions](references/dql/dql-functions-time.md). They support calendar and time zones properly including DST.

--- a/skills/dt-dql-essentials/references/dql/dql-data-types.md
+++ b/skills/dt-dql-essentials/references/dql/dql-data-types.md
@@ -6,7 +6,7 @@
 | `binary` | Binary | A sequence of bytes. |
 | `boolean` | Boolean | Boolean has only two possible values: true and false. |
 | `double` | Double | Double-precision 64-bit IEEE 754 floating point. |
-| `duration` | Duration | A duration between two timestamps, consisting of an amount and a time unit |
+| `duration` | Duration | A duration between two timestamps, consisting of an amount and a time unit. The amount may be fractional on fixed-length units (`ns`, `us`, `ms`, `s`, `m`, `h`) but **not** on the calendar units `d` and `w` |
 | `long` | Long | The signed long has a minimum value of -2^63 and a maximum value of 2^63-1 |
 | `record` | Record | A set of key-value pair data whose value can be any DQL data type. |
 | `string` | String | Sequence of characters with a specified character set. |


### PR DESCRIPTION
## Problem

Duration literals accept **fractional amounts** on fixed-length units. The skill doesn't mention it — and, more usefully, doesn't mention the exception: the **calendar units `d` and `w` reject fractions**, because a day or week has no fixed nanosecond count (DST, leap seconds).

Both halves cost the reader something:

- An author who writes `0.25d` expecting six hours gets `CALENDAR_DURATION_UNIT_NOT_SUPPORTED_FOR_FRACTIONAL_AMOUNT` with no hint that `6h` is how to express it.
- An author who assumes fractions are unsupported reaches for nanosecond arithmetic — which this same skill already tells them to avoid ("Avoid converting timestamps and durations to double/long … and constants expressing time units as nanoseconds").

## Change

One rule under **Modifying Time**, and the `duration` row in the data-types table.

## Verification — live tenant, 2026-08-11

Run with `data record(...)`, zero bytes scanned:

| Literal | Result |
|---|---|
| `0.5h` | `1800000000000` ns |
| `0.25h` | `900000000000` ns |
| `1.5m` | `90000000000` ns |
| `1.5s` | `1500000000` ns |
| `1.5ms` / `1.5us` | `1500000` / `1500` ns |
| `1.5ns` | **`1`** — truncates; nanosecond is the precision floor |
| `0.25d` | ❌ `CALENDAR_DURATION_UNIT_NOT_SUPPORTED_FOR_FRACTIONAL_AMOUNT` |
| `1.5w` | ❌ same |

`fetch logs, from:-0.5h` also verifies as valid, so the rule holds in timeframe parameters as well as expressions.

## Timing note

Worth recording for anyone who re-checks: this was first tested on **2026-05-29 and fractional literals did not parse then** — `0.5h` was rejected outright. The behavior was version-gated and has since reached the tenant. A sufficiently old environment will still show the earlier behavior.