### PR TITLE
Fix plugin marketplace metadata per Anthropic directory review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,10 @@
 {
   "name": "dynatrace-for-ai",
-  "description": "Dynatrace observability skills and knowledge packages for AI coding agents.",
   "owner": { "name": "Dynatrace" },
   "plugins": [
     {
       "name": "dynatrace",
-      "description": "Dynatrace observability skills for AI agents.",
+      "description": "Dynatrace observability skills and knowledge packages for AI coding agents.",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,6 @@
   "homepage": "https://www.dynatrace.com",
   "repository": "https://github.com/Dynatrace/dynatrace-for-ai",
   "license": "Apache-2.0",
+  "privacyPolicy": "https://www.dynatrace.com/company/trust-center/privacy/",
   "mcpServers": "./.mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Please consult the [Dynatrace MCP server docs
 
 Update with `claude plugin marketplace update && claude plugin update dynatrace@dynatrace-for-ai`.
 
+The bundled MCP server connects to your Dynatrace environment. See the [Dynatrace Privacy Policy](https://www.dynatrace.com/company/trust-center/privacy/) for details on data handling.
+
 ### Manual
 
 Copy skill directories into your agent's skills path (`.agents/skills/`, `.claude/skills/`, `.cursor/skills/`, etc.).


### PR DESCRIPTION
## Summary
Addresses feedback from Anthropic's Claude Code plugin directory review on this submission:

- **Privacy policy link**: the plugin ships a remote MCP connector (`.mcp.json`) to the Dynatrace MCP gateway. Directory policy requires a clear, accessible privacy-policy link for software connecting to a remote service. Added `privacyPolicy` to `.claude-plugin/plugin.json` and a matching link in the README.
- **marketplace.json schema**: `.claude-plugin/marketplace.json` had a root-level `description` key, but the marketplace schema expects it inside the `plugins[]` entry — strict parsers reject the root-level key. Moved the description into `plugins[0]`.

## Test plan
- [x] Validated both JSON files parse correctly
- [ ] Re-submit to Claude Code plugin directory for review