### PR TITLE
feat: add X-Http-Source header and version consistency check

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace",
-  "version": "0.3.0",
+  "version": "7.0.0",
   "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
   "author": { "name": "Dynatrace" },
   "homepage": "https://www.dynatrace.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynatrace",
   "displayName": "Dynatrace",
-  "version": "0.2.0",
+  "version": "7.0.0",
   "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
   "author": { "name": "Dynatrace" },
   "homepage": "https://www.dynatrace.com",

--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -1,0 +1,21 @@
+name: Check Version Consistency
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - run: node scripts/check-versions.js

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "url": "${DT_ENVIRONMENT}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
       "headers": {
         "Authorization": "Bearer ${DT_PLATFORM_TOKEN}",
-        "X-Http-Source": "dynatrace-for-ai/0.2.0"
+        "X-Http-Source": "dynatrace-for-ai/7.0.0"
       }
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,8 @@
       "type": "http",
       "url": "${DT_ENVIRONMENT}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
       "headers": {
-        "Authorization": "Bearer ${DT_PLATFORM_TOKEN}"
+        "Authorization": "Bearer ${DT_PLATFORM_TOKEN}",
+        "X-Http-Source": "dynatrace-for-ai/0.2.0"
       }
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,3 @@ Consult the [Dynatrace MCP server docs
 ## Skills for Observability related questions
 
 Please use the included skills for observability related questions.
-
-## Version consistency
-
-The canonical version lives in `.claude-plugin/plugin.json` (`version` field). It must match the latest GitHub release tag (e.g., release `v7.0.0` → version `7.0.0`).
-
-When bumping that version, update all of the following to match:
-- `.cursor-plugin/plugin.json` → `"version"`
-- `mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
-- `.mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
-
-The CI workflow `.github/workflows/check-versions.yml` enforces this and will fail if they drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,13 @@ Consult the [Dynatrace MCP server docs
 ## Skills for Observability related questions
 
 Please use the included skills for observability related questions.
+
+## Version consistency
+
+The canonical version lives in `.cursor-plugin/plugin.json` (`version` field).
+
+When bumping that version, also update `X-Http-Source` in **both** MCP config files to match:
+- `mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
+- `.mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
+
+The CI workflow `.github/workflows/check-versions.yml` enforces this and will fail if they drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,10 @@ Please use the included skills for observability related questions.
 
 ## Version consistency
 
-The canonical version lives in `.cursor-plugin/plugin.json` (`version` field).
+The canonical version lives in `.claude-plugin/plugin.json` (`version` field). It must match the latest GitHub release tag (e.g., release `v7.0.0` → version `7.0.0`).
 
-When bumping that version, also update `X-Http-Source` in **both** MCP config files to match:
+When bumping that version, update all of the following to match:
+- `.cursor-plugin/plugin.json` → `"version"`
 - `mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
 - `.mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,19 @@ The following files live exclusively in this repository and welcome PRs:
 To report bugs, suggest new skills, or request improvements to existing skill
 content, please [open a GitHub issue](../../issues/new).
 
+## Releasing a New Version
+
+The canonical version is the `version` field in `.claude-plugin/plugin.json`. It must match the GitHub release tag (e.g., release `v7.0.0` → `"version": "7.0.0"`).
+
+When bumping the version, update all of the following to match:
+
+- `.claude-plugin/plugin.json` → `"version"` (canonical)
+- `.cursor-plugin/plugin.json` → `"version"`
+- `mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
+- `.mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
+
+Run `node scripts/check-versions.js` to verify — CI also enforces this on every PR.
+
 ## License
 
 All contributions are licensed under Apache-2.0.

--- a/mcp.json
+++ b/mcp.json
@@ -4,7 +4,7 @@
       "url": "${env:DT_ENVIRONMENT}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
       "headers": {
         "Authorization": "Bearer ${env:DT_PLATFORM_TOKEN}",
-        "X-Http-Source": "dynatrace-for-ai/0.2.0"
+        "X-Http-Source": "dynatrace-for-ai/7.0.0"
       }
     }
   }

--- a/mcp.json
+++ b/mcp.json
@@ -3,7 +3,8 @@
     "dynatrace": {
       "url": "${env:DT_ENVIRONMENT}/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
       "headers": {
-        "Authorization": "Bearer ${env:DT_PLATFORM_TOKEN}"
+        "Authorization": "Bearer ${env:DT_PLATFORM_TOKEN}",
+        "X-Http-Source": "dynatrace-for-ai/0.2.0"
       }
     }
   }

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// Verifies that X-Http-Source in mcp.json and .mcp.json matches the version in .cursor-plugin/plugin.json
+// Verifies that all version fields are consistent with .claude-plugin/plugin.json (canonical source).
+// Run on CI and locally before releasing.
 const fs = require("fs");
 const path = require("path");
 
@@ -9,22 +10,38 @@ function read(file) {
   return JSON.parse(fs.readFileSync(path.join(root, file), "utf8"));
 }
 
-const { version } = read(".cursor-plugin/plugin.json");
-const expected = `dynatrace-for-ai/${version}`;
+const { version } = read(".claude-plugin/plugin.json");
+const expectedHeader = `dynatrace-for-ai/${version}`;
 
 const checks = [
-  { file: "mcp.json", actual: read("mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"] },
-  { file: ".mcp.json", actual: read(".mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"] },
+  {
+    file: ".cursor-plugin/plugin.json",
+    actual: read(".cursor-plugin/plugin.json").version,
+    expected: version,
+  },
+  {
+    file: "mcp.json",
+    actual: read("mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"],
+    expected: expectedHeader,
+  },
+  {
+    file: ".mcp.json",
+    actual: read(".mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"],
+    expected: expectedHeader,
+  },
 ];
 
 let failed = false;
-for (const { file, actual } of checks) {
+for (const { file, actual, expected } of checks) {
   if (actual !== expected) {
-    console.error(`FAIL ${file}: X-Http-Source is "${actual}", expected "${expected}"`);
+    console.error(`FAIL ${file}: got "${actual}", expected "${expected}"`);
     failed = true;
   } else {
-    console.log(`OK   ${file}: X-Http-Source = "${actual}"`);
+    console.log(`OK   ${file}: "${actual}"`);
   }
 }
 
-if (failed) process.exit(1);
+if (failed) {
+  console.error(`\nCanonical version is "${version}" from .claude-plugin/plugin.json`);
+  process.exit(1);
+}

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Verifies that X-Http-Source in mcp.json and .mcp.json matches the version in .cursor-plugin/plugin.json
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+
+function read(file) {
+  return JSON.parse(fs.readFileSync(path.join(root, file), "utf8"));
+}
+
+const { version } = read(".cursor-plugin/plugin.json");
+const expected = `dynatrace-for-ai/${version}`;
+
+const checks = [
+  { file: "mcp.json", actual: read("mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"] },
+  { file: ".mcp.json", actual: read(".mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"] },
+];
+
+let failed = false;
+for (const { file, actual } of checks) {
+  if (actual !== expected) {
+    console.error(`FAIL ${file}: X-Http-Source is "${actual}", expected "${expected}"`);
+    failed = true;
+  } else {
+    console.log(`OK   ${file}: X-Http-Source = "${actual}"`);
+  }
+}
+
+if (failed) process.exit(1);


### PR DESCRIPTION
Fixes #30

## Summary

- Add `X-Http-Source: dynatrace-for-ai/<version>` header to `mcp.json` and `.mcp.json` for source tracking in Dynatrace observability
- Bump all plugin versions from stale `0.2.0`/`0.3.0` to `7.0.0` (current release) — fixes Claude Code plugin update detection
- Add `scripts/check-versions.js`: reads `.claude-plugin/plugin.json` as canonical, checks `.cursor-plugin/plugin.json` and both MCP headers match
- Add `.github/workflows/check-versions.yml` CI workflow that runs the check on every push/PR to `main`
- Add `CLAUDE.md` rule documenting canonical source and which files must stay in sync

## Version files kept in sync

| File | Field | Value |
|---|---|---|
| `.claude-plugin/plugin.json` | `version` (canonical) | `7.0.0` |
| `.cursor-plugin/plugin.json` | `version` | `7.0.0` |
| `mcp.json` | `X-Http-Source` header | `dynatrace-for-ai/7.0.0` |
| `.mcp.json` | `X-Http-Source` header | `dynatrace-for-ai/7.0.0` |

## Test plan

- [ ] `node scripts/check-versions.js` passes locally (all files report OK)
- [ ] CI workflow runs green on this PR
- [ ] Bump version in `.claude-plugin/plugin.json` without updating other files → CI fails