### PR TITLE
docs: update Cursor and Claude Code plugin descriptions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dynatrace",
   "version": "7.0.0",
-  "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
+  "description": "Connect Claude Code to your Dynatrace environment and investigate production issues, review deployments, and check for vulnerabilities using real data pulled directly into your session: root cause details, logs, metrics, traces, and CPU/memory profiling. Ask in plain language and get answers grounded in what's actually happening in your environment, not just documentation summaries. Use Dynatrace Skills, alongside the MCP server, query your environment without leaving Claude Code. To also execute workflows and create dashboards directly from Claude, just upgrade your experience and install our DTCTL (Open source CLI for the Dynatrace Platform)",
   "author": { "name": "Dynatrace" },
   "homepage": "https://www.dynatrace.com",
   "repository": "https://github.com/Dynatrace/dynatrace-for-ai",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dynatrace",
   "displayName": "Dynatrace",
   "version": "7.0.0",
-  "description": "Dynatrace observability skills. DQL query patterns, application and infrastructure monitoring, log analysis, problem investigation, and incident response workflows. Use with dtctl or the Dynatrace MCP server (https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server) for live platform access.",
+  "description": "Connect Cursor to your Dynatrace environment and investigate production issues, review deployments, and check for vulnerabilities using real data pulled directly into your session: root cause details, logs, metrics, traces, and CPU/memory profiling. Ask in plain language and get answers grounded in what's actually happening in your environment, not just documentation summaries. Use dtctl, the open source CLI for the Dynatrace platform, alongside the MCP server to manage dashboards, run workflows, and query your environment without leaving Cursor.",
   "author": { "name": "Dynatrace" },
   "homepage": "https://www.dynatrace.com",
   "repository": "https://github.com/Dynatrace/dynatrace-for-ai",


### PR DESCRIPTION
## Summary

- Rewrite `.cursor-plugin/plugin.json` `description` to lead with what the plugin does (connect Cursor to a live Dynatrace environment, investigate issues with real data, use dtctl + MCP server) instead of the generic observability-skills blurb.
- Rewrite `.claude-plugin/plugin.json` `description` with the Claude Code equivalent, including a call-out to install dtctl for workflow execution and dashboard creation.

Note: fixed a typo in the requested Cursor copy ("onnect" → "Connect") to match the Claude Code description's phrasing.

## Test plan

- [ ] Both files remain valid JSON (verified locally with `python3 -m json.tool`)
- [ ] Rendered description displays correctly in the Cursor and Claude Code plugin listings