### PR TITLE
feat: publish server.json to the official MCP registry

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MCP_PUBLISHER_URL: https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+
 jobs:
   check-versions:
     runs-on: ubuntu-latest
@@ -19,3 +22,18 @@ jobs:
         with:
           node-version: "lts/*"
       - run: node scripts/check-versions.js
+      # The registry grants only io.github.<owner>/* and compares case-sensitively,
+      # so a wrong-case name would only fail at publish time with a 403.
+      - name: Check server.json name matches the GitHub namespace
+        run: |
+          expected="io.github.${GITHUB_REPOSITORY%%/*}/${GITHUB_REPOSITORY##*/}"
+          actual=$(jq -r .name server.json)
+          if [ "$expected" != "$actual" ]; then
+            echo "FAIL server.json (name): got \"$actual\", expected \"$expected\""
+            exit 1
+          fi
+          echo "OK   server.json (name): \"$actual\""
+      - name: Validate server.json for the MCP registry
+        run: |
+          curl -fsSL "$MCP_PUBLISHER_URL" | tar xz mcp-publisher
+          ./mcp-publisher validate

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,40 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  MCP_PUBLISHER_URL: https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # The OIDC token can publish to the whole io.github.<owner>/* namespace, so gate
+    # the job behind an environment with required reviewers.
+    environment: mcp-registry-publish
+    permissions:
+      # OIDC grants the io.github.<owner>/* namespace, so no secret is needed
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check the tag matches the server.json version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          actual=$(jq -r .version server.json)
+          if [ "$tag" != "$actual" ]; then
+            echo "FAIL tag v$tag does not match server.json version \"$actual\""
+            exit 1
+          fi
+      - name: Install mcp-publisher
+        run: curl -fsSL "$MCP_PUBLISHER_URL" | tar xz mcp-publisher
+      - name: Authenticate to the MCP registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server.json
+        run: ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ __pycache__/
 *.swp
 *.swo
 *~
+
+# mcp-publisher credentials and binary
+.mcp_publisher_token
+mcp-publisher

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ When bumping the version, update all of the following to match:
 
 Run `node scripts/check-versions.js` to verify — CI also enforces this on every PR.
 
+Pushing the `vX.Y.Z` tag also publishes `server.json` to the
+[official MCP registry](https://registry.modelcontextprotocol.io) via
+`.github/workflows/publish-mcp.yml`. The workflow authenticates with GitHub OIDC, which grants
+only the `io.github.<owner>/*` namespace — and the registry compares namespaces
+case-sensitively. So `server.json` → `"name"` must keep the exact `io.github.Dynatrace/`
+casing, otherwise publishing fails with a 403.
+
+The first publish of a version whose tag already existed before the workflow must be started
+manually with `workflow_dispatch`. The job runs in the `mcp-registry-publish` environment:
+configure that environment with required reviewers, because the OIDC token can publish to the
+whole `io.github.Dynatrace/*` namespace.
+
 ## License
 
 All contributions are licensed under Apache-2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ When bumping the version, update all of the following to match:
 - `.cursor-plugin/plugin.json` → `"version"`
 - `mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
 - `.mcp.json` → `"X-Http-Source": "dynatrace-for-ai/<version>"`
+- `server.json` → `"version"` and the `X-Http-Source` header value
 
 Run `node scripts/check-versions.js` to verify — CI also enforces this on every PR.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Or install the dtctl skill with dtctl itself: `dtctl skills install`
 
 The **[Dynatrace MCP server](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server)** provides Dynatrace API access via MCP. The Claude Code plugin bundles the MCP server configuration automatically — just set `DT_ENVIRONMENT` and `DT_PLATFORM_TOKEN` as shown above. For other agents that support MCP natively, see the [MCP server docs](https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server).
 
+The MCP server is remote — Dynatrace hosts it, so there is nothing to install. Releases are published to the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.Dynatrace/dynatrace-for-ai`, so MCP hosts that read the registry can add it by name.
+
 ## Skills
 
 ### DQL & Query Language

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -13,6 +13,11 @@ function read(file) {
 const { version } = read(".claude-plugin/plugin.json");
 const expectedHeader = `dynatrace-for-ai/${version}`;
 
+const serverJson = read("server.json");
+const serverJsonXHttpSource = serverJson.remotes?.[0]?.headers?.find(
+  (h) => h.name === "X-Http-Source"
+)?.value;
+
 const checks = [
   {
     file: ".cursor-plugin/plugin.json",
@@ -27,6 +32,16 @@ const checks = [
   {
     file: ".mcp.json",
     actual: read(".mcp.json").mcpServers?.dynatrace?.headers?.["X-Http-Source"],
+    expected: expectedHeader,
+  },
+  {
+    file: "server.json (version)",
+    actual: serverJson.version,
+    expected: version,
+  },
+  {
+    file: "server.json (X-Http-Source)",
+    actual: serverJsonXHttpSource,
     expected: expectedHeader,
   },
 ];

--- a/server.json
+++ b/server.json
@@ -1,13 +1,22 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.dynatrace/dynatrace-for-ai",
+  "name": "io.github.Dynatrace/dynatrace-for-ai",
   "title": "Dynatrace",
   "description": "Connect AI assistants to Dynatrace to query observability data and analyze problems.",
   "version": "7.0.0",
   "repository": {
     "url": "https://github.com/Dynatrace/dynatrace-for-ai",
-    "source": "github"
+    "source": "github",
+    "id": "1197177849"
   },
+  "websiteUrl": "https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/Dynatrace/dynatrace-for-ai/main/Dynatrace_Logo_color_positive.png",
+      "mimeType": "image/png",
+      "sizes": ["1280x1280"]
+    }
+  ],
   "remotes": [
     {
       "type": "streamable-http",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.dynatrace/dynatrace-for-ai",
+  "title": "Dynatrace",
+  "description": "Connect AI assistants to Dynatrace to query observability data and analyze problems.",
+  "version": "7.0.0",
+  "repository": {
+    "url": "https://github.com/Dynatrace/dynatrace-for-ai",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{environment_id}.apps.dynatrace.com/platform-reserved/mcp-gateway/v0.1/servers/dynatrace-mcp/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Dynatrace Platform Token with MCP gateway scopes",
+          "value": "Bearer {platform_token}",
+          "isRequired": true,
+          "isSecret": true,
+          "variables": {
+            "platform_token": {
+              "description": "Your Dynatrace Platform Token with MCP gateway scopes",
+              "isRequired": true,
+              "isSecret": true,
+              "format": "string"
+            }
+          }
+        },
+        {
+          "name": "X-Http-Source",
+          "value": "dynatrace-for-ai/7.0.0"
+        }
+      ],
+      "variables": {
+        "environment_id": {
+          "description": "Your Dynatrace environment ID, e.g. abc12345 from https://abc12345.apps.dynatrace.com",
+          "isRequired": true,
+          "format": "string"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `server.json` for the Dynatrace remote MCP server **and** the automation to publish it.

github.com/mcp does not accept direct submissions: publishers push to
[registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) and GitHub ingests
from there.

- `server.json` following the [MCP registry schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) — `streamable-http`, Bearer (platform token) auth, static `X-Http-Source` header, plus `websiteUrl`, `icons` and `repository.id` for listing quality
- `.github/workflows/publish-mcp.yml` — publishes on `v*` tags or `workflow_dispatch`, authenticates with GitHub OIDC (no secrets), gated on the `mcp-registry-publish` environment, and refuses to run if the tag does not match the `server.json` version
- `check-versions.yml` — adds a namespace guard and `mcp-publisher validate` (pinned to v1.8.1)
- `scripts/check-versions.js` already covers `server.json` version and `X-Http-Source`

### Why the name has a capital D

`io.github.Dynatrace/dynatrace-for-ai`, not `io.github.dynatrace/...`. The registry grants
`io.github.<repository_owner>/*` from the raw GitHub OIDC claim
([`github_oidc.go:293`](https://github.com/modelcontextprotocol/registry/blob/main/internal/api/handlers/v0/auth/github_oidc.go#L293))
and matches it with a case-sensitive prefix
([`jwt.go:169`](https://github.com/modelcontextprotocol/registry/blob/main/internal/auth/jwt.go#L169)).
The org login is `Dynatrace`, so the lowercase form would fail with a 403 at publish time.
`mcp-publisher validate` does **not** catch this — verified — which is why CI checks the name
against `$GITHUB_REPOSITORY` instead.

This lands as a separate entry alongside the existing `io.github.dynatrace-oss/Dynatrace-mcp`
(npm/stdio, v1.5.0) — a different artifact (hosted gateway vs. npm stdio package) from a
different repo. `title` and `description` are unchanged from the first commit.

## Test plan

- [x] `mcp-publisher 1.8.1 validate` → `server.json is valid`
- [x] namespace guard passes, and fails on the lowercase name
- [x] tag guard passes on `v7.0.0`, fails on `v8.0.0`
- [x] `node scripts/check-versions.js` → 5 × OK
- [x] `tests/run-all.sh` → 2 passed
- [x] icon URL returns 200 `image/png`

## Before merging

- [x] Configure the `mcp-registry-publish` environment. Done: required reviewers
  (`christian-kreuzberger-dtx`, `discostu105`, `philipp-ham`), deployment refs limited to branch
  `main` and tag `v*`.
- [x] Optional: uncheck "Allow administrators to bypass configured protection rules". It is still
  on, so a repo admin can publish to `io.github.Dynatrace/*` without an approval. Keep it if you
  want an emergency-publish path.

## After merging

- [ ] First publish must be a manual `workflow_dispatch` — `v7.0.0` predates the workflow, so no tag push will fire.
- [ ] Onboarding to github.com/mcp is still manual curation ([confirmed by a GitHub maintainer, 2026-05-19](https://github.com/github/github-mcp-server/discussions/1257)); email `partnerships@github.com` after the first publish. Later versions then sync automatically.

## Known trade-off

`mcp-publisher validate` is a remote call to the registry, so registry downtime will redden PRs.
Easy to move to a non-blocking job if that becomes noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

